### PR TITLE
ATC-3520: added fallback mechanism to try to use BWELL_ENV variable t…

### DIFF
--- a/spark_pipeline_framework/utilities/api_helper/http_request.py
+++ b/spark_pipeline_framework/utilities/api_helper/http_request.py
@@ -169,7 +169,7 @@ class HelixHttpRequest:
         # remove None arguments
         arguments = {k: v for k, v in arguments.items() if v is not None}
 
-        response = self._send_request(request_function, arguments=arguments)  # type: ignore
+        response = self._send_request(request_function, arguments=arguments)
         if self.raise_error:
             try:
                 response.raise_for_status()

--- a/spark_pipeline_framework/utilities/elastic_search/elastic_search_connection.py
+++ b/spark_pipeline_framework/utilities/elastic_search/elastic_search_connection.py
@@ -62,6 +62,7 @@ class ElasticSearchConnection:
                 f"Unable to find SSM path via ENV: {path}; trying to use BWELL_ENV instead: {bwell_path}"
             )
             db_config = get_ssm_config(path=bwell_path)
+            path = bwell_path
 
         username = db_config[f"{path}username"]
         password = db_config[f"{path}password"]


### PR DESCRIPTION
…o construct the proper SSM path for getting OpenSearch credentials, if the path is invalid when using ENV variable