### PR TITLE
HDS-269 update parquet writer loader

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -119,11 +119,11 @@
         },
         "alembic": {
             "hashes": [
-                "sha256:3db4ce81a9072e1b5aa44c2d202add24553182672a12daf21608d6f62a8f9cf9",
-                "sha256:d6c96c2482740592777c400550a523bc7a9aada4e210cae2e733354ddae6f6f8"
+                "sha256:03226222f1cf943deee6c85d9464261a6c710cd19b4fe867a3ad1f25afda610f",
+                "sha256:8e7645c32e4f200675e69f0745415335eb59a3663f5feb487abfa0b30c45888b"
             ],
             "index": "pypi",
-            "version": "==1.11.3"
+            "version": "==1.12.0"
         },
         "async-timeout": {
             "hashes": [
@@ -143,19 +143,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b505faa126db84e226f6f8d242a798fae30a725f0cac8a76c6aca9ace4e8eb28",
-                "sha256:ed787f250ce2562c7744395bdf32b5a7bc9184126ef50a75e97bcb66043dccf3"
+                "sha256:734bf24b9240a366b4a0d7e37433ef01664a3568d8bb65be583cc2a4ed2947c5",
+                "sha256:9f36834a1a777002b4b4600415ced83bc62d42b9c36d8c75f5fc007a58d0ae17"
             ],
             "index": "pypi",
-            "version": "==1.28.32"
+            "version": "==1.28.42"
         },
         "botocore": {
             "hashes": [
-                "sha256:7a07d8dc8cc47bf23af39409ada81f388eb78233e1bb2cde0c415756da753664",
-                "sha256:8992ac186988c4b4cc168e8e479e9472da1442b193c1bf7c9dcd1877ec62d23c"
+                "sha256:a51607e9f367e53768d37eacde244bc31dbaff4e7dde453cc772a8f75648f04a",
+                "sha256:cedf7d5eb55f120faadd56d3bced2139523479adb4df62c0c5ee5d46b2ffa836"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.32"
+            "version": "==1.31.42"
         },
         "bounded-pool-executor": {
             "hashes": [
@@ -394,11 +394,11 @@
         },
         "fsspec": {
             "hashes": [
-                "sha256:1cbad1faef3e391fba6dc005ae9b5bdcbf43005c9167ce78c915549c352c869a",
-                "sha256:d0b2f935446169753e7a5c5c55681c54ea91996cc67be93c39a154fb3a2742af"
+                "sha256:4dbf0fefee035b7c6d3bbbe6bc99b2f201f40d4dca95b67c2b719be77bcd917f",
+                "sha256:d55b9ab2a4c1f2b759888ae9f93e40c2aa72c0808132e87e282b549f9e6c4254"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2023.6.0"
+            "version": "==2023.9.0"
         },
         "furl": {
             "hashes": [
@@ -418,16 +418,17 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:8d9b8cb1e80b9735e8717c9362079d3ce4c6e5ddeebedd0361b228c3a67a62f6",
-                "sha256:e3d59b1c2c6ebb9dfa7a184daf3b6dd4914237e7488a1730a6d8f6f5d0b4187f"
+                "sha256:5d3802b98a3bae1c2b8ae0e1ff2e4aa16bcdf02c145da34d092324f599f01395",
+                "sha256:85f7d365d1f6bf677ae51039c1ef67ca59091c7ebd5a3509aa399d4eda02d6dd"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.32"
+            "version": "==3.1.34"
         },
         "greenlet": {
             "hashes": [
                 "sha256:03a8f4f3430c3b3ff8d10a2a86028c660355ab637cee9333d63d66b56f09d52a",
                 "sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a",
+                "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1",
                 "sha256:18a7f18b82b52ee85322d7a7874e676f34ab319b9f8cce5de06067384aa8ff43",
                 "sha256:18e98fb3de7dba1c0a852731c3070cf022d14f0d68b4c87a19cc1016f3bb8b33",
                 "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8",
@@ -453,6 +454,7 @@
                 "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91",
                 "sha256:7cafd1208fdbe93b67c7086876f061f660cfddc44f404279c1585bbf3cdc64c5",
                 "sha256:7efde645ca1cc441d6dc4b48c0f7101e8d86b54c8530141b09fd31cef5149ec9",
+                "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417",
                 "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8",
                 "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b",
                 "sha256:910841381caba4f744a44bf81bfd573c94e10b3045ee00de0cbf436fe50673a6",
@@ -476,8 +478,10 @@
                 "sha256:c9c59a2120b55788e800d82dfa99b9e156ff8f2227f07c5e3012a45a399620b7",
                 "sha256:cd021c754b162c0fb55ad5d6b9d960db667faad0fa2ff25bb6e1301b0b6e6a75",
                 "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae",
+                "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47",
                 "sha256:d5508f0b173e6aa47273bdc0a0b5ba055b59662ba7c7ee5119528f466585526b",
                 "sha256:d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470",
+                "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c",
                 "sha256:db1a39669102a1d8d12b57de2bb7e2ec9066a6f2b3da35ae511ff93b01b5d564",
                 "sha256:dbfcfc0218093a19c252ca8eb9aee3d29cfdcb586df21049b9d777fd32c14fd9",
                 "sha256:e0f72c9ddb8cd28532185f54cc1453f2c16fb417a08b53a855c4e6a418edd099",
@@ -753,22 +757,22 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:06437f0d4bb0d5f29e3d392aba69600188d4be5ad1e0a3370e581a9bf75a3081",
-                "sha256:0b2b224e9541fe9f046dd7317d05f08769c332b7e4c54d93c7f0f372dedb0b1a",
-                "sha256:302e8752c760549ed4c7a508abc86b25d46553c81989343782809e1a062a2ef9",
-                "sha256:44837a5ed9c9418ad5d502f89f28ba102e9cd172b6668bc813f21716f9273348",
-                "sha256:55dd644adc27d2a624339332755fe077c7f26971045b469ebb9732a69ce1f2ca",
-                "sha256:5906c5e79ff50fe38b2d49d37db5874e3c8010826f2362f79996d83128a8ed9b",
-                "sha256:5d32363d14aca6e5c9e9d5918ad8fb65b091b6df66740ae9de50ac3916055e43",
-                "sha256:970c701ee16788d74f3de20938520d7a0aebc7e4fff37096a48804c80d2908cf",
-                "sha256:bd39b9094a4cc003a1f911b847ab379f89059f478c0b611ba1215053e295132e",
-                "sha256:d414199ca605eeb498adc4d2ba82aedc0379dca4a7c364ff9bc9a179aa28e71b",
-                "sha256:d4af4fd9e9418e819be30f8df2a16e72fbad546a7576ac7f3653be92a6966d30",
-                "sha256:df015c47d6855b8efa0b9be706c70bf7f050a4d5ac6d37fb043fbd95157a0e25",
-                "sha256:fc361148e902949dcb953bbcb148c99fe8f8854291ad01107e4120361849fd0e"
+                "sha256:237b9a50bd3b7307d0d834c1b0eb1a6cd47d3f4c2da840802cd03ea288ae8880",
+                "sha256:25ae91d21e3ce8d874211110c2f7edd6384816fb44e06b2867afe35139e1fd1c",
+                "sha256:2b23bd6e06445699b12f525f3e92a916f2dcf45ffba441026357dea7fa46f42b",
+                "sha256:3b7b170d3491ceed33f723bbf2d5a260f8a4e23843799a3906f16ef736ef251e",
+                "sha256:4e69965e7e54de4db989289a9b971a099e626f6167a9351e9d112221fc691bc1",
+                "sha256:58e12d2c1aa428ece2281cef09bbaa6938b083bcda606db3da4e02e991a0d924",
+                "sha256:6bd26c1fa9038b26c5c044ee77e0ecb18463e957fefbaeb81a3feb419313a54e",
+                "sha256:77700b55ba41144fc64828e02afb41901b42497b8217b558e4a001f18a85f2e3",
+                "sha256:7fda70797ddec31ddfa3576cbdcc3ddbb6b3078b737a1a87ab9136af0570cd6e",
+                "sha256:839952e759fc40b5d46be319a265cf94920174d88de31657d5622b5d8d6be5cd",
+                "sha256:bb7aa97c252279da65584af0456f802bd4b2de429eb945bbc9b3d61a42a8cd16",
+                "sha256:c00c3c7eb9ad3833806e21e86dca448f46035242a680f81c3fe068ff65e79c74",
+                "sha256:c5cdd486af081bf752225b26809d2d0a85e575b80a84cde5172a05bbb1990099"
             ],
             "index": "pypi",
-            "version": "==4.24.1"
+            "version": "==4.24.2"
         },
         "py4j": {
             "hashes": [
@@ -913,14 +917,16 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588",
-                "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
+                "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
+                "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
             ],
-            "version": "==2023.3"
+            "version": "==2023.3.post1"
         },
         "pyyaml": {
             "hashes": [
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
                 "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
                 "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
                 "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
                 "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
@@ -928,7 +934,10 @@
                 "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
                 "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
                 "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
                 "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
                 "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
                 "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
                 "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
@@ -936,9 +945,12 @@
                 "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
                 "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
                 "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
                 "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
                 "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
                 "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
@@ -953,7 +965,9 @@
                 "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
                 "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
                 "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
                 "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
                 "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
                 "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
                 "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
@@ -1001,11 +1015,11 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:b4c9ae193ad6d3e7add50944b86afa0d150bd821ab8ec21edb26d9a06b66f6a8",
-                "sha256:d5238825fe9a9340645fac3d75b287c08fbb99fb2b422477de781c9f5f09e019"
+                "sha256:8d3ef7e6997e8e42dd55c74166ed21e6ac70664caa32dd940b26d54a8f6b4142",
+                "sha256:be3c92c246fbe80ebce8fbacb180494a481a77fcdcb7c1aadb2ea5b9c2bee8b9"
             ],
             "index": "pypi",
-            "version": "==6.3.0"
+            "version": "==6.4.0"
         },
         "smmap": {
             "hashes": [
@@ -1017,11 +1031,11 @@
         },
         "spark-nlp": {
             "hashes": [
-                "sha256:690a9509bea5adddb55557539ca8fc1a8b949e73fb69499007829ae857284050",
-                "sha256:898da78131364934dcaa715d8a763ec751e06b2d901a07fe5ca0c1a03d51ce47"
+                "sha256:404716b23f60448a7bd668297eac78beaaa40afb3819e679464d72b8928ce931",
+                "sha256:fed71757358c40d57d5d12bd9511e5e0112925cd00ddbf788ceb935db7aaac20"
             ],
             "index": "pypi",
-            "version": "==5.0.2"
+            "version": "==5.1.0"
         },
         "sparkautomapper": {
             "hashes": [
@@ -1323,11 +1337,11 @@
         },
         "autoflake": {
             "hashes": [
-                "sha256:62e1f74a0fdad898a96fee6f99fe8241af90ad99c7110c884b35855778412251",
-                "sha256:de409b009a34c1c2a7cc2aae84c4c05047f9773594317c6a6968bd497600d4a0"
+                "sha256:265cde0a43c1f44ecfb4f30d95b0437796759d07be7706a2f70e4719234c0f79",
+                "sha256:62b7b6449a692c3c9b0c916919bbc21648da7281e8506bcf8d3f8280e431ebc1"
             ],
             "index": "pypi",
-            "version": "==2.2.0"
+            "version": "==2.2.1"
         },
         "babel": {
             "hashes": [
@@ -1365,35 +1379,35 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b505faa126db84e226f6f8d242a798fae30a725f0cac8a76c6aca9ace4e8eb28",
-                "sha256:ed787f250ce2562c7744395bdf32b5a7bc9184126ef50a75e97bcb66043dccf3"
+                "sha256:734bf24b9240a366b4a0d7e37433ef01664a3568d8bb65be583cc2a4ed2947c5",
+                "sha256:9f36834a1a777002b4b4600415ced83bc62d42b9c36d8c75f5fc007a58d0ae17"
             ],
             "index": "pypi",
-            "version": "==1.28.32"
+            "version": "==1.28.42"
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:871fe959a25bdf40f28e93dcdb6208756c0d1b979e9ead309ebcc3a8e59c5695",
-                "sha256:f985fa8115340181b33229bcb6efa27b21bcb243f6a2842c22cee8da7996d1e7"
+                "sha256:496075f1de47e3984d9a367798d2c46ae7405fa0142b2668ba3ff2f2c2982b3f",
+                "sha256:8bc7382eab400e81824bdb2444f9268641aa76dcbe84a145f7afc9a4bfad76ff"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.32"
+            "version": "==1.28.42"
         },
         "botocore": {
             "hashes": [
-                "sha256:7a07d8dc8cc47bf23af39409ada81f388eb78233e1bb2cde0c415756da753664",
-                "sha256:8992ac186988c4b4cc168e8e479e9472da1442b193c1bf7c9dcd1877ec62d23c"
+                "sha256:a51607e9f367e53768d37eacde244bc31dbaff4e7dde453cc772a8f75648f04a",
+                "sha256:cedf7d5eb55f120faadd56d3bced2139523479adb4df62c0c5ee5d46b2ffa836"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.32"
+            "version": "==1.31.42"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:1388a81ac6bfb4d63ea97d3216e3e12dcd3965dce09eebc86e530b474401872c",
-                "sha256:8b2879788ea7ba6fc5a3d2d6cfb331323f111ebe24959bbefafecb6ea194541a"
+                "sha256:172e2178f0683cdef1006a360deb82cafee4d4974bea53fdc40fb27f47997222",
+                "sha256:215a55fe840fe621d7fe6406bbe369ea98443340b6ce233961b17f20ae61869f"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==1.31.32"
+            "version": "==1.31.42"
         },
         "cached-property": {
             "hashes": [
@@ -1675,11 +1689,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81",
-                "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"
+                "sha256:0ecc1dd2ec4672a10c8550a8182f1bd0c0a5088470ecd5a125e45f49472fac3d",
+                "sha256:f067e40ccc40f2b48395a80fcbd4728262fab54e232e090a4063ab804179efeb"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.12.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.12.3"
         },
         "helix-mockserver-client": {
             "hashes": [
@@ -1900,11 +1914,11 @@
         },
         "moto": {
             "hashes": [
-                "sha256:00fbae396fc48c3596e47b4e3267c1a41ca01c968de023beb68e774c63910b58",
-                "sha256:e4835912f05627b6a53b938562b717122230fb038d023819133f8526f60ed0a7"
+                "sha256:2a9cbcd9da1a66b23f95d62ef91968284445233a606b4de949379395056276fb",
+                "sha256:ee34c4c3f53900d953180946920c9dba127a483e2ed40e6dbf93d4ae2e760e7c"
             ],
             "index": "pypi",
-            "version": "==4.2.0"
+            "version": "==4.2.2"
         },
         "mypy": {
             "hashes": [
@@ -2053,19 +2067,19 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
-                "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"
+                "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
+                "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3.0"
         },
         "pre-commit": {
             "hashes": [
-                "sha256:10badb65d6a38caff29703362271d7dca483d01da88f9d7e05d0b97171c136cb",
-                "sha256:a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023"
+                "sha256:6bbd5129a64cad4c0dfaeeb12cd8f7ea7e15b77028d985341478c8af3c759522",
+                "sha256:96d529a951f8b677f730a7212442027e8ba53f9b04d217c4c67dc56c393ad945"
             ],
             "index": "pypi",
-            "version": "==3.3.3"
+            "version": "==3.4.0"
         },
         "py4j": {
             "hashes": [
@@ -2114,11 +2128,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
-                "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
+                "sha256:2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab",
+                "sha256:460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f"
             ],
             "index": "pypi",
-            "version": "==7.4.0"
+            "version": "==7.4.1"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -2138,7 +2152,9 @@
         },
         "pyyaml": {
             "hashes": [
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
                 "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
                 "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
                 "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
                 "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
@@ -2146,7 +2162,10 @@
                 "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
                 "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
                 "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
                 "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
                 "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
                 "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
                 "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
@@ -2154,9 +2173,12 @@
                 "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
                 "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
                 "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
                 "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
                 "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
                 "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
@@ -2171,7 +2193,9 @@
                 "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
                 "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
                 "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
                 "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
                 "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
                 "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
                 "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
@@ -2264,11 +2288,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d",
-                "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"
+                "sha256:00478ca80aeebeecb2f288d3206b0de568df5cd2b8fada1209843cc9a8d88a48",
+                "sha256:af3d5949030c3f493f550876b2fd1dd5ec66689c4ee5d5344f009746f71fd5a8"
             ],
             "index": "pypi",
-            "version": "==68.1.2"
+            "version": "==68.2.0"
         },
         "six": {
             "hashes": [
@@ -2407,11 +2431,11 @@
         },
         "types-awscrt": {
             "hashes": [
-                "sha256:0e31d7ba44e1898af37d224b94d28ffaef19baf89bb18ea2599de9ac0910a07f",
-                "sha256:eaef60422cf716b4ae216f164b74d679c82b0d9c53db380a37deb29ae5579b1b"
+                "sha256:61833aa140e724a9098025610f4b8cde3dcf65b842631d7447378f9f5db4e1fd",
+                "sha256:68fffeb75396e9e7614cd930b2d52295f680230774750907bcafb56f11514043"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.19.0"
+            "version": "==0.19.1"
         },
         "types-boto3": {
             "hashes": [
@@ -2485,11 +2509,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:95a6e9398b4967fbcb5fef2acec5efaf9aa4972049d9ae41f95e0972a683fd02",
-                "sha256:e5c3b4ce817b0b328af041506a2a299418c98747c4b1e68cb7527e74ced23efc"
+                "sha256:29c70bb9b88510f6414ac3e55c8b413a1f96239b6b789ca123437d5e892190cb",
+                "sha256:772b05bfda7ed3b8ecd16021ca9716273ad9f4467c801f27e83ac73430246dca"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.24.3"
+            "version": "==20.24.4"
         },
         "vistir": {
             "hashes": [

--- a/spark_pipeline_framework/transformers/framework_base_exporter/v1/framework_base_exporter.py
+++ b/spark_pipeline_framework/transformers/framework_base_exporter/v1/framework_base_exporter.py
@@ -83,6 +83,10 @@ class FrameworkBaseExporter(FrameworkTransformer):
                     df = df.limit(limit)
                 writer = df.write if not stream else df.writeStream
 
+                # To fix errors in writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z
+                if format_ == "parquet":
+                    df.sql_ctx.setConf('spark.sql.parquet.datetimeRebaseModeInWrite', 'CORRECTED')
+
                 writer = writer.format(format_)
 
                 if isinstance(writer, DataFrameWriter):

--- a/spark_pipeline_framework/transformers/framework_base_exporter/v1/framework_base_exporter.py
+++ b/spark_pipeline_framework/transformers/framework_base_exporter/v1/framework_base_exporter.py
@@ -85,7 +85,9 @@ class FrameworkBaseExporter(FrameworkTransformer):
 
                 # To fix errors in writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z
                 if format_ == "parquet":
-                    df.sql_ctx.setConf('spark.sql.parquet.datetimeRebaseModeInWrite', 'CORRECTED')
+                    df.sql_ctx.setConf(
+                        "spark.sql.parquet.datetimeRebaseModeInWrite", "CORRECTED"
+                    )
 
                 writer = writer.format(format_)
 

--- a/spark_pipeline_framework/transformers/framework_parquet_exporter/v1/test/test_person.json
+++ b/spark_pipeline_framework/transformers/framework_parquet_exporter/v1/test/test_person.json
@@ -1,0 +1,134 @@
+[
+  {
+    "resourceType": "Patient",
+    "id": "P111999",
+    "meta": {
+      "versionId": "1",
+      "lastUpdated": "2023-07-24T23:19:56.000Z",
+      "source": "https://risehealth.innovaccer.com/aidbox-fhir/Patient/P111999",
+      "security": [
+        {
+          "system": "https://www.icanbwell.com/owner",
+          "code": "rise_silver"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "rise_silver"
+        },
+        {
+          "system": "https://www.icanbwell.com/vendor",
+          "code": "innovaccer"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "innovaccer"
+        },
+        {
+          "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+          "code": "rise_silver"
+        }
+      ]
+    },
+    "identifier": [
+      {
+        "system": "urn:identifier:Silver_Health:patient_id",
+        "value": "102549"
+      },
+      {
+        "system": "urn:identifier:innovaccer:empi",
+        "value": "P111999"
+      },
+      {
+        "id": "sourceId",
+        "system": "https://www.icanbwell.com/sourceId",
+        "value": "P111999"
+      },
+      {
+        "id": "uuid",
+        "system": "https://www.icanbwell.com/uuid",
+        "value": "08265d52-9976-5e83-8bbb-99ce4b17e1c0"
+      }
+    ],
+    "name": [
+      {
+        "text": "Luffy Pirate",
+        "family": "Pirate",
+        "given": [
+          "Luffy"
+        ]
+      }
+    ],
+    "telecom": [
+      {
+        "system": "phone",
+        "value": "2229990000",
+        "use": "home"
+      },
+      {
+        "system": "email",
+        "value": "luffy_the_king_of_pirates@gmail.com"
+      }
+    ],
+    "gender": "male",
+    "birthDate": "1582-01-01",
+    "deceasedBoolean": false,
+    "address": [
+      {
+        "line": [
+          "9999 Beyond Way"
+        ],
+        "city": "GrandSea",
+        "state": "HW",
+        "postalCode": "88888",
+        "country": "US"
+      }
+    ],
+    "maritalStatus": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+          "version": "4.0.1",
+          "code": "S",
+          "display": "Never Married"
+        }
+      ]
+    },
+    "communication": [
+      {
+        "language": {
+          "coding": [
+            {
+              "system": "urn:ietf:bcp:47",
+              "version": "4.0.1",
+              "code": "en",
+              "display": "English"
+            }
+          ]
+        },
+        "preferred": true
+      }
+    ],
+    "generalPractitioner": [
+      {
+        "extension": [
+          {
+            "id": "sourceId",
+            "url": "https://www.icanbwell.com/sourceId",
+            "valueString": "Practitioner/83c292de"
+          },
+          {
+            "id": "uuid",
+            "url": "https://www.icanbwell.com/uuid",
+            "valueString": "Practitioner/9a265fbd"
+          },
+          {
+            "id": "sourceAssigningAuthority",
+            "url": "https://www.icanbwell.com/sourceAssigningAuthority",
+            "valueString": "rise_silver"
+          }
+        ],
+        "reference": "Practitioner/83c292de"
+      }
+    ]
+  }
+]

--- a/spark_pipeline_framework/transformers/framework_parquet_exporter/v1/test/test_person_json_can_save_parquet.py
+++ b/spark_pipeline_framework/transformers/framework_parquet_exporter/v1/test/test_person_json_can_save_parquet.py
@@ -1,0 +1,66 @@
+import shutil
+import datetime
+from os import path
+from pathlib import Path
+
+from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.session import SparkSession
+from pyspark.sql.types import StructType
+
+from spark_fhir_schemas.r4.resources.person import (
+    PersonSchema,
+)
+
+from spark_pipeline_framework.transformers.framework_json_loader.v1.framework_json_loader import (
+    FrameworkJsonLoader,
+)
+from spark_pipeline_framework.transformers.framework_parquet_exporter.v1.framework_parquet_exporter import (
+    FrameworkParquetExporter,
+)
+from spark_pipeline_framework.transformers.framework_parquet_loader.v1.framework_parquet_loader import (
+    FrameworkParquetLoader,
+)
+from tests.spark_test_helper import SparkTestHelper
+
+
+def test_person_json_can_save_parquet(spark_session: SparkSession) -> None:
+    # Arrange
+    SparkTestHelper.clear_tables(spark_session)
+
+    data_dir: Path = Path(__file__).parent.joinpath("./")
+    test_file_path: str = f"{data_dir.joinpath('test_person.json')}"
+
+    if path.isdir(data_dir.joinpath("temp")):
+        shutil.rmtree(data_dir.joinpath("temp"))
+
+    schema = StructType([])
+
+    df: DataFrame = spark_session.createDataFrame(
+        spark_session.sparkContext.emptyRDD(), schema
+    )
+
+    FrameworkJsonLoader(
+        view="my_view",
+        file_path=test_file_path,
+        schema=PersonSchema.get_schema(include_extension=True)
+    ).transform(df)
+
+    parquet_file_path: str = (
+        f"file://{data_dir.joinpath('temp/').joinpath(f'test.parquet')}"
+    )
+
+    # Act
+    FrameworkParquetExporter(view="my_view", file_path=parquet_file_path).transform(df)
+
+    # Assert
+    FrameworkParquetLoader(view="my_view2", file_path=parquet_file_path).transform(df)
+
+    # noinspection SqlDialectInspection
+    result: DataFrame = spark_session.sql("SELECT * FROM my_view2")
+
+    result.show()
+
+    assert result.count() == 1
+
+    assert result.select('id').collect()[0][0] == "P111999"
+    assert result.select('birthDate').collect()[0][0] == datetime.date(1582, 1, 1)

--- a/spark_pipeline_framework/transformers/framework_parquet_exporter/v1/test/test_person_json_can_save_parquet.py
+++ b/spark_pipeline_framework/transformers/framework_parquet_exporter/v1/test/test_person_json_can_save_parquet.py
@@ -42,7 +42,7 @@ def test_person_json_can_save_parquet(spark_session: SparkSession) -> None:
     FrameworkJsonLoader(
         view="my_view",
         file_path=test_file_path,
-        schema=PersonSchema.get_schema(include_extension=True)
+        schema=PersonSchema.get_schema(include_extension=True),  # type: ignore
     ).transform(df)
 
     parquet_file_path: str = (
@@ -62,5 +62,5 @@ def test_person_json_can_save_parquet(spark_session: SparkSession) -> None:
 
     assert result.count() == 1
 
-    assert result.select('id').collect()[0][0] == "P111999"
-    assert result.select('birthDate').collect()[0][0] == datetime.date(1582, 1, 1)
+    assert result.select("id").collect()[0][0] == "P111999"
+    assert result.select("birthDate").collect()[0][0] == datetime.date(1582, 1, 1)

--- a/spark_pipeline_framework/transformers/framework_parquet_loader/v1/framework_parquet_loader.py
+++ b/spark_pipeline_framework/transformers/framework_parquet_loader/v1/framework_parquet_loader.py
@@ -118,6 +118,10 @@ class FrameworkParquetLoader(FrameworkTransformer):
             name=f"{name or view}_table_loader", progress_logger=progress_logger
         ):
             try:
+                # To fix errors in reading dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z
+                if format_ == "parquet":
+                    df.sql_ctx.setConf('spark.sql.parquet.datetimeRebaseModeInRead', 'CORRECTED')
+
                 df_reader: Union[DataFrameReader, DataStreamReader] = (
                     df.sql_ctx.read if not stream else df.sql_ctx.readStream
                 )

--- a/spark_pipeline_framework/transformers/framework_parquet_loader/v1/framework_parquet_loader.py
+++ b/spark_pipeline_framework/transformers/framework_parquet_loader/v1/framework_parquet_loader.py
@@ -120,7 +120,9 @@ class FrameworkParquetLoader(FrameworkTransformer):
             try:
                 # To fix errors in reading dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z
                 if format_ == "parquet":
-                    df.sql_ctx.setConf('spark.sql.parquet.datetimeRebaseModeInRead', 'CORRECTED')
+                    df.sql_ctx.setConf(
+                        "spark.sql.parquet.datetimeRebaseModeInRead", "CORRECTED"
+                    )
 
                 df_reader: Union[DataFrameReader, DataStreamReader] = (
                     df.sql_ctx.read if not stream else df.sql_ctx.readStream


### PR DESCRIPTION
* added a config to address errors in writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z in JSON- `"spark.sql.parquet.datetimeRebaseModeInWrite", "CORRECTED"`. same applied for `ModeInRead` as well.