### PR TITLE
updated to make register_udfs() generic for future usages

### DIFF
--- a/spark_pipeline_framework/utilities/udf_registrar/v1/udf_registrar.py
+++ b/spark_pipeline_framework/utilities/udf_registrar/v1/udf_registrar.py
@@ -1,15 +1,36 @@
+from typing import Dict, List, Optional
+
 # noinspection PyProtectedMember
 from pyspark.sql import SparkSession
-from pyspark.sql.types import StringType, MapType
+from pyspark.sql.types import DataType
 
 
-def register_udfs(session: SparkSession) -> None:
+def register_udfs(session: SparkSession, udf_infos: List[Dict[str, str]]) -> None:
     """
     Adds registration for udfs
-    :param session:
+    :param session: Spark session
+    :param udf_infos: UDF context info.
+        for example,
+        [
+            {
+                "name": "runCqlLibrary",                                     # UDF name for Spark
+                "javaClassName": "com.bwell.services.spark.RunCqlLibrary",   # Fully qualified name of java class
+                "returnType": MapType(StringType(), StringType())            # Optional. The return type of the registered Java function.
+                                                                             #   The value can be either a :class:`pyspark.sql.types.DataType` object or a DDL-formatted type string.
+            }
+        ]
     """
-    session.udf.registerJavaFunction(
-        "runCqlLibrary",
-        "com.bwell.services.spark.RunCqlLibrary",
-        MapType(StringType(), StringType()),
-    )
+
+    for udf_info in udf_infos:
+        udf_name: str = str(udf_info.get("name", None))
+        java_class_name: str = str(udf_info.get("javaClassName", None))
+        return_type: Optional[DataType | str] = udf_info.get(
+            "returnType", None
+        )  # Optional
+
+        if udf_name and java_class_name:
+            session.udf.registerJavaFunction(
+                udf_name,
+                java_class_name,
+                return_type,
+            )

--- a/spark_pipeline_framework/utilities/udf_registrar/v1/udf_registrar.py
+++ b/spark_pipeline_framework/utilities/udf_registrar/v1/udf_registrar.py
@@ -1,11 +1,11 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 # noinspection PyProtectedMember
 from pyspark.sql import SparkSession
 from pyspark.sql.types import DataType
 
 
-def register_udfs(session: SparkSession, udf_infos: List[Dict[str, str]]) -> None:
+def register_udfs(session: SparkSession, udf_infos: List[Dict[str, Any]]) -> None:
     """
     Adds registration for udfs
     :param session: Spark session


### PR DESCRIPTION
updated the method, `register_udfs` to be generic and configurable, as currently it has hard-coded values