### PR TITLE
add attributes to child telemetry spans

### DIFF
--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -77,6 +77,8 @@ class FrameworkPipeline(Transformer):
                 span_id=None,
                 service_name=os.getenv("OTEL_SERVICE_NAME", "helix.pipelines"),
                 environment=os.getenv("ENV", "development"),
+                attributes=attributes,
+                log_level=log_level,
             )
         )
 

--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -75,7 +75,7 @@ class FrameworkPipeline(Transformer):
                 ),
                 trace_id=None,
                 span_id=None,
-                service_name=os.getenv("OTEL_SERVICE_NAME", "helix.pipelines"),
+                service_name=os.getenv("OTEL_SERVICE_NAME", "helix-pipelines"),
                 environment=os.getenv("ENV", "development"),
                 attributes=attributes,
                 log_level=log_level,

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -108,6 +108,8 @@ class FrameworkPipeline(Transformer):
                 span_id=None,
                 service_name=os.getenv("OTEL_SERVICE_NAME", "helix.pipelines"),
                 environment=os.getenv("ENV", "development"),
+                attributes=attributes,
+                log_level=log_level,
             )
         )
 

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -106,7 +106,7 @@ class FrameworkPipeline(Transformer):
                 ),
                 trace_id=None,
                 span_id=None,
-                service_name=os.getenv("OTEL_SERVICE_NAME", "helix.pipelines"),
+                service_name=os.getenv("OTEL_SERVICE_NAME", "helix-pipelines"),
                 environment=os.getenv("ENV", "development"),
                 attributes=attributes,
                 log_level=log_level,

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
@@ -183,6 +183,10 @@ class ConsoleTelemetry(Telemetry):
     async def flush_async(self) -> None:
         pass
 
+    @override
+    async def shutdown_async(self) -> None:
+        pass
+
     def __getstate__(self) -> Dict[str, Any]:
         # Exclude certain properties from being pickled otherwise they cause errors in pickling
         return {k: v for k, v in self.__dict__.items()}
@@ -194,6 +198,7 @@ class ConsoleTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Counter:
         """
         Get a counter metric
@@ -201,6 +206,7 @@ class ConsoleTelemetry(Telemetry):
         :param name: Name of the counter
         :param unit: Unit of the counter
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
         return NoOpCounter(
@@ -216,6 +222,7 @@ class ConsoleTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> UpDownCounter:
         """
         Get a up_down_counter metric
@@ -223,6 +230,7 @@ class ConsoleTelemetry(Telemetry):
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
 
@@ -233,12 +241,13 @@ class ConsoleTelemetry(Telemetry):
         )
 
     @override
-    def get_histograms(
+    def get_histogram(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Histogram:
         """
         Get a histograms metric
@@ -246,6 +255,7 @@ class ConsoleTelemetry(Telemetry):
         :param name: Name of the histograms
         :param unit: Unit of the histograms
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
         return NoOpHistogram(

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
@@ -43,6 +43,10 @@ class NullTelemetry(Telemetry):
     async def flush_async(self) -> None:
         pass
 
+    @override
+    async def shutdown_async(self) -> None:
+        pass
+
     @contextmanager
     @override
     def trace(
@@ -82,6 +86,7 @@ class NullTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Counter:
         """
         Get a counter metric
@@ -89,6 +94,7 @@ class NullTelemetry(Telemetry):
         :param name: Name of the counter
         :param unit: Unit of the counter
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
         return NoOpCounter(
@@ -104,6 +110,7 @@ class NullTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> UpDownCounter:
         """
         Get a up_down_counter metric
@@ -111,6 +118,7 @@ class NullTelemetry(Telemetry):
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
 
@@ -121,12 +129,13 @@ class NullTelemetry(Telemetry):
         )
 
     @override
-    def get_histograms(
+    def get_histogram(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Histogram:
         """
         Get a histograms metric
@@ -134,6 +143,7 @@ class NullTelemetry(Telemetry):
         :param name: Name of the histograms
         :param unit: Unit of the histograms
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
         return NoOpHistogram(

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
@@ -450,7 +450,7 @@ class OpenTelemetry(Telemetry):
         if current_span:
             current_span.add_event(event_name, attributes=attributes or {})
 
-    def shutdown(self) -> None:
+    async def shutdown_async(self) -> None:
         """
         Gracefully shutdown the tracer provider
         """
@@ -536,6 +536,7 @@ class OpenTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Counter:
         """
         Get a counter metric
@@ -543,11 +544,13 @@ class OpenTelemetry(Telemetry):
         :param name: Name of the counter
         :param unit: Unit of the counter
         :param description: Description
+        :param attributes: Additional attributes
         :return: The Counter metric
         """
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
+            attributes=attributes,
         )
 
         # check if we already have a counter for this name
@@ -571,6 +574,7 @@ class OpenTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> UpDownCounter:
         """
         Get a up_down_counter metric
@@ -578,11 +582,13 @@ class OpenTelemetry(Telemetry):
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
         :param description: Description
+        :param attributes: Additional attributes
         :return: The Counter metric
         """
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
+            attributes=attributes,
         )
 
         # check if we already have an up_down_counter for this name
@@ -600,12 +606,13 @@ class OpenTelemetry(Telemetry):
         return up_down_counter
 
     @override
-    def get_histograms(
+    def get_histogram(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Histogram:
         """
         Get a histograms metric
@@ -613,11 +620,13 @@ class OpenTelemetry(Telemetry):
         :param name: Name of the histograms
         :param unit: Unit of the histograms
         :param description: Description
+        :param attributes: Additional attributes
         :return: The Counter metric
         """
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
+            attributes=attributes,
         )
 
         # check if we already have a histograms for this name

--- a/spark_pipeline_framework/utilities/telemetry/telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry.py
@@ -4,7 +4,6 @@ from opentelemetry.metrics import Counter, UpDownCounter, Histogram
 
 from typing import Optional, Dict, Any, AsyncIterator, Iterator
 
-
 from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
     TelemetryParent,
 )
@@ -105,12 +104,16 @@ class Telemetry(ABC):
     async def flush_async(self) -> None: ...
 
     @abstractmethod
+    async def shutdown_async(self) -> None: ...
+
+    @abstractmethod
     def get_counter(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Counter:
         """
         Get a counter metric
@@ -118,6 +121,7 @@ class Telemetry(ABC):
         :param name: Name of the counter
         :param unit: Unit of the counter
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
         ...
@@ -129,6 +133,7 @@ class Telemetry(ABC):
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> UpDownCounter:
         """
         Get a up_down_counter metric
@@ -136,17 +141,19 @@ class Telemetry(ABC):
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
         ...
 
     @abstractmethod
-    def get_histograms(
+    def get_histogram(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> Histogram:
         """
         Get a histograms metric
@@ -154,6 +161,7 @@ class Telemetry(ABC):
         :param name: Name of the histograms
         :param unit: Unit of the histograms
         :param description: Description
+        :param attributes: Optional attributes
         :return: The Counter metric
         """
         ...

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Optional, List
+from typing import Optional, List, Any, Dict, Union
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -21,6 +21,12 @@ class TelemetryContext(DataClassJsonMixin):
 
     environment: str
     """ Environment for the telemetry context """
+
+    attributes: Optional[Dict[str, Any]]
+    """ Additional attributes to include in telemetry """
+
+    log_level: Optional[Union[int, str]]
+    """ Log level for the telemetry context """
 
     trace_id: Optional[str] = None
     """ Trace ID for the telemetry context """
@@ -50,6 +56,8 @@ class TelemetryContext(DataClassJsonMixin):
             span_id=None,
             service_name="",
             environment="",
+            attributes=None,
+            log_level=None,
         )
 
     def copy(self) -> "TelemetryContext":
@@ -65,6 +73,8 @@ class TelemetryContext(DataClassJsonMixin):
             service_name=self.service_name,
             environment=self.environment,
             trace_all_calls=self.trace_all_calls,
+            attributes=self.attributes,
+            log_level=self.log_level,
         )
 
     def create_child_context(

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
@@ -20,6 +20,8 @@ def test_open_telemetry() -> None:
         provider=TelemetryProvider.OPEN_TELEMETRY,
         service_name="example-service",
         environment="development",
+        attributes=None,
+        log_level=None,
     )
     telemetry = OpenTelemetry(telemetry_context=telemetry_context, log_level="DEBUG")
 

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
@@ -14,7 +14,7 @@ from spark_pipeline_framework.utilities.telemetry.open_telemetry import (
 
 
 @pytest.mark.skip(reason="This test is for manual testing only")
-def test_open_telemetry() -> None:
+async def test_open_telemetry_async() -> None:
     # Initialize telemetry
     telemetry_context = TelemetryContext(
         provider=TelemetryProvider.OPEN_TELEMETRY,
@@ -43,4 +43,4 @@ def test_open_telemetry() -> None:
         telemetry.add_event("operation_completed", {"key": "value"})
 
         # Shutdown telemetry
-        telemetry.shutdown()
+        await telemetry.shutdown_async()

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
@@ -161,4 +161,4 @@ async def test_open_telemetry_multi_thread() -> None:
     time.sleep(1)  # Give time for export
 
     # Shutdown properly
-    telemetry.shutdown()
+    await telemetry.shutdown_async()

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
@@ -88,6 +88,8 @@ async def run_sub_operation(
         service_name=service_name,
         environment=environment,
         provider=TelemetryProvider.OPEN_TELEMETRY,
+        attributes=None,
+        log_level=None,
     )
     telemetry = OpenTelemetry(
         telemetry_context=telemetry_context,
@@ -114,6 +116,8 @@ async def test_open_telemetry_multi_thread() -> None:
         service_name=service_name,
         environment=environment,
         provider=TelemetryProvider.OPEN_TELEMETRY,
+        attributes=None,
+        log_level=None,
     )
     telemetry = OpenTelemetry(
         telemetry_context=telemetry_context,


### PR DESCRIPTION
1. Service Name Change:
   - In multiple files (`framework_pipeline.py`), the default service name has been changed from `"helix.pipelines"` to `"helix-pipelines"` (note the hyphen instead of a dot).

2. Telemetry Enhancements:
   - Several methods in telemetry-related classes have been updated to include new optional parameters:
     - `attributes`: An optional dictionary to add custom attributes to telemetry metrics
     - `log_level`: An optional parameter to set log levels
   - A new `shutdown_async()` method has been added to replace the synchronous `shutdown()` method
   - Renamed `get_histograms()` to `get_histogram()` (singular)

3. OpenTelemetry Initialization Improvements:
   - Added support for reading Docker image version from environment variables
   - Enhanced logging and resource attribute creation
   - Added more flexibility in setting log levels and metadata

4. Test Updates:
   - Updated test cases to match the new async `shutdown_async()` method
   - Added parameters for new telemetry context attributes