### PR TITLE
add set attributes to telemetry_span_wrapper.py

### DIFF
--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
@@ -2,6 +2,7 @@ from typing import (
     Optional,
     Dict,
     Any,
+    override,
 )
 
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
@@ -17,6 +18,7 @@ from spark_pipeline_framework.utilities.telemetry.telemetry_span_wrapper import 
 
 
 class ConsoleTelemetrySpanWrapper(TelemetrySpanWrapper):
+    @override
     @property
     def span_id(self) -> Optional[str]:
         return (
@@ -25,6 +27,7 @@ class ConsoleTelemetrySpanWrapper(TelemetrySpanWrapper):
             else None
         )
 
+    @override
     @property
     def trace_id(self) -> Optional[str]:
         return (
@@ -47,3 +50,7 @@ class ConsoleTelemetrySpanWrapper(TelemetrySpanWrapper):
             telemetry_context=telemetry_context,
             telemetry_parent=telemetry_parent,
         )
+
+    @override
+    def set_attributes(self, attributes: Dict[str, Any]) -> None:
+        pass

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
@@ -2,6 +2,7 @@ from typing import (
     Optional,
     Dict,
     Any,
+    override,
 )
 
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
@@ -47,3 +48,7 @@ class NullTelemetrySpanWrapper(TelemetrySpanWrapper):
             telemetry_context=telemetry_context,
             telemetry_parent=telemetry_parent,
         )
+
+    @override
+    def set_attributes(self, attributes: Dict[str, Any]) -> None:
+        pass

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
@@ -48,3 +48,7 @@ class OpenTelemetrySpanWrapper(TelemetrySpanWrapper):
             return None
         span_id_hex = f"{span_context.span_id:016x}"
         return span_id_hex
+
+    @override
+    def set_attributes(self, attributes: Dict[str, Any]) -> None:
+        self._span.set_attributes(attributes=attributes)

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
@@ -79,3 +79,6 @@ class TelemetrySpanWrapper(ABC):
         )
 
         return child_telemetry_parent
+
+    @abstractmethod
+    def set_attributes(self, attributes: Dict[str, Any]) -> None: ...


### PR DESCRIPTION

1. The pull request adds the `@override` decorator to several methods in different telemetry-related classes:
   - `span_id` and `trace_id` methods in `ConsoleTelemetrySpanWrapper`
   - `__init__` method in `NullTelemetrySpanWrapper`
   - `span_id` method in `OpenTelemetrySpan`

2. A new abstract method `set_attributes` is added to the base `TelemetrySpanWrapper` class, which is then implemented in the child classes:
   - `ConsoleTelemetrySpanWrapper` and `NullTelemetrySpanWrapper` have an empty implementation (just `pass`)
   - `OpenTelemetrySpan` actually sets the attributes on the span
