### PR TITLE
Add attributes to counters

### DIFF
--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -79,6 +79,7 @@ class FrameworkPipeline(Transformer):
                 environment=os.getenv("ENV", "development"),
                 attributes=attributes,
                 log_level=log_level,
+                instance_name=self.parameters.get("flow_run_name", "unknown"),
             )
         )
 

--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -79,8 +79,13 @@ class FrameworkPipeline(Transformer):
                 environment=os.getenv("ENV", "development"),
                 attributes=attributes,
                 log_level=log_level,
-                instance_name=self.parameters.get("flow_run_name", "unknown"),
-                service_namespace="helix-pipelines",
+                instance_name=os.getenv(
+                    "OTEL_INSTANCE_NAME",
+                    self.parameters.get("flow_run_name", "unknown"),
+                ),
+                service_namespace=os.getenv(
+                    "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
+                ),
             )
         )
 

--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -80,6 +80,7 @@ class FrameworkPipeline(Transformer):
                 attributes=attributes,
                 log_level=log_level,
                 instance_name=self.parameters.get("flow_run_name", "unknown"),
+                service_namespace="helix-pipelines",
             )
         )
 

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -110,6 +110,7 @@ class FrameworkPipeline(Transformer):
                 environment=os.getenv("ENV", "development"),
                 attributes=attributes,
                 log_level=log_level,
+                instance_name=self.parameters.get("flow_run_name", "unknown"),
             )
         )
 

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -111,6 +111,7 @@ class FrameworkPipeline(Transformer):
                 attributes=attributes,
                 log_level=log_level,
                 instance_name=self.parameters.get("flow_run_name", "unknown"),
+                service_namespace="helix-pipelines",
             )
         )
 

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -110,8 +110,13 @@ class FrameworkPipeline(Transformer):
                 environment=os.getenv("ENV", "development"),
                 attributes=attributes,
                 log_level=log_level,
-                instance_name=self.parameters.get("flow_run_name", "unknown"),
-                service_namespace="helix-pipelines",
+                instance_name=os.getenv(
+                    "OTEL_INSTANCE_NAME",
+                    self.parameters.get("flow_run_name", "unknown"),
+                ),
+                service_namespace=os.getenv(
+                    "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
+                ),
             )
         )
 

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
@@ -13,7 +13,6 @@ from typing import (
     Union,
 )
 
-from opentelemetry.metrics import Counter, UpDownCounter, Histogram
 from opentelemetry.metrics import NoOpCounter, NoOpUpDownCounter, NoOpHistogram
 
 from spark_pipeline_framework.logger.yarn_logger import get_logger
@@ -22,6 +21,15 @@ from spark_pipeline_framework.utilities.telemetry.console_telemetry_history_item
 )
 from spark_pipeline_framework.utilities.telemetry.console_telemetry_span_wrapper import (
     ConsoleTelemetrySpanWrapper,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
+    TelemetryCounter,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_counter import (
+    TelemetryHistogram,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
+    TelemetryUpDownCounter,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry import (
     Telemetry,
@@ -43,6 +51,7 @@ class ConsoleTelemetry(Telemetry):
     _current_context_variable: ContextVar[Optional[TelemetryParent]] = ContextVar(
         _CONTEXT_KEY, default=None
     )
+
     # _current_thread_context_variable: TypedThreadLocal[Optional[TelemetryContext]] = (
     #     TypedThreadLocal()
     # )
@@ -199,7 +208,7 @@ class ConsoleTelemetry(Telemetry):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Counter:
+    ) -> TelemetryCounter:
         """
         Get a counter metric
 
@@ -209,10 +218,13 @@ class ConsoleTelemetry(Telemetry):
         :param attributes: Optional attributes
         :return: The Counter metric
         """
-        return NoOpCounter(
-            name=name,
-            unit=unit,
-            description=description,
+        return TelemetryCounter(
+            counter=NoOpCounter(
+                name=name,
+                unit=unit,
+                description=description,
+            ),
+            attributes=None,
         )
 
     @override
@@ -223,9 +235,9 @@ class ConsoleTelemetry(Telemetry):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> UpDownCounter:
+    ) -> TelemetryUpDownCounter:
         """
-        Get a up_down_counter metric
+        Get an up_down_counter metric
 
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
@@ -233,11 +245,13 @@ class ConsoleTelemetry(Telemetry):
         :param attributes: Optional attributes
         :return: The Counter metric
         """
-
-        return NoOpUpDownCounter(
-            name=name,
-            unit=unit,
-            description=description,
+        return TelemetryUpDownCounter(
+            counter=NoOpUpDownCounter(
+                name=name,
+                unit=unit,
+                description=description,
+            ),
+            attributes=None,
         )
 
     @override
@@ -248,7 +262,7 @@ class ConsoleTelemetry(Telemetry):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Histogram:
+    ) -> TelemetryHistogram:
         """
         Get a histograms metric
 
@@ -258,8 +272,11 @@ class ConsoleTelemetry(Telemetry):
         :param attributes: Optional attributes
         :return: The Counter metric
         """
-        return NoOpHistogram(
-            name=name,
-            unit=unit,
-            description=description,
+        return TelemetryHistogram(
+            histogram=NoOpHistogram(
+                name=name,
+                unit=unit,
+                description=description,
+            ),
+            attributes=None,
         )

--- a/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_counter.py
+++ b/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_counter.py
@@ -1,0 +1,29 @@
+from typing import Optional, Dict, Any, Union
+
+from opentelemetry.context import Context
+from opentelemetry.metrics import Counter
+
+
+class TelemetryCounter:
+    """
+    This class wraps the OpenTelemetry Counter class and adds the supplied attributes every time a metric is recorded
+
+    """
+
+    def __init__(
+        self, *, counter: Counter, attributes: Optional[Dict[str, Any]]
+    ) -> None:
+        assert counter
+        self._counter: Counter = counter
+        self._attributes: Optional[Dict[str, Any]] = attributes
+
+    def add(
+        self,
+        amount: Union[int, float],
+        attributes: Optional[Dict[str, Any]] = None,
+        context: Optional[Context] = None,
+    ) -> None:
+        attributes = attributes or {}
+        attributes.update(self._attributes or {})
+
+        self._counter.add(amount=amount, attributes=attributes, context=context)

--- a/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_histogram_counter.py
+++ b/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_histogram_counter.py
@@ -1,0 +1,29 @@
+from typing import Optional, Dict, Any, Union
+
+from opentelemetry.context import Context
+from opentelemetry.metrics import Histogram
+
+
+class TelemetryHistogram:
+    """
+    This class wraps the OpenTelemetry Histogram class and adds the supplied attributes every time a metric is recorded
+
+    """
+
+    def __init__(
+        self, *, histogram: Histogram, attributes: Optional[Dict[str, Any]]
+    ) -> None:
+        assert histogram
+        self._histogram: Histogram = histogram
+        self._attributes: Optional[Dict[str, Any]] = attributes
+
+    def record(
+        self,
+        amount: Union[int, float],
+        attributes: Optional[Dict[str, Any]] = None,
+        context: Optional[Context] = None,
+    ) -> None:
+        attributes = attributes or {}
+        attributes.update(self._attributes or {})
+
+        self._histogram.record(amount=amount, attributes=attributes, context=context)

--- a/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_up_down_counter.py
+++ b/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_up_down_counter.py
@@ -1,0 +1,29 @@
+from typing import Optional, Dict, Any, Union
+
+from opentelemetry.context import Context
+from opentelemetry.metrics import UpDownCounter
+
+
+class TelemetryUpDownCounter:
+    """
+    This class wraps the OpenTelemetry UpDownCounter class and adds the supplied attributes every time a metric is recorded
+
+    """
+
+    def __init__(
+        self, *, counter: UpDownCounter, attributes: Optional[Dict[str, Any]]
+    ) -> None:
+        assert counter
+        self._counter: UpDownCounter = counter
+        self._attributes: Optional[Dict[str, Any]] = attributes
+
+    def add(
+        self,
+        amount: Union[int, float],
+        attributes: Optional[Dict[str, Any]] = None,
+        context: Optional[Context] = None,
+    ) -> None:
+        attributes = attributes or {}
+        attributes.update(self._attributes or {})
+
+        self._counter.add(amount=amount, attributes=attributes, context=context)

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
@@ -1,6 +1,15 @@
 from contextlib import contextmanager, asynccontextmanager
 from typing import Optional, Dict, Any, Iterator, AsyncIterator, override
 
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
+    TelemetryCounter,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_counter import (
+    TelemetryHistogram,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
+    TelemetryUpDownCounter,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
@@ -15,7 +24,6 @@ from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
 from spark_pipeline_framework.utilities.telemetry.telemetry_span_wrapper import (
     TelemetrySpanWrapper,
 )
-from opentelemetry.metrics import Counter, UpDownCounter, Histogram
 from opentelemetry.metrics import NoOpCounter, NoOpUpDownCounter, NoOpHistogram
 
 
@@ -87,7 +95,7 @@ class NullTelemetry(Telemetry):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Counter:
+    ) -> TelemetryCounter:
         """
         Get a counter metric
 
@@ -97,10 +105,13 @@ class NullTelemetry(Telemetry):
         :param attributes: Optional attributes
         :return: The Counter metric
         """
-        return NoOpCounter(
-            name=name,
-            unit=unit,
-            description=description,
+        return TelemetryCounter(
+            counter=NoOpCounter(
+                name=name,
+                unit=unit,
+                description=description,
+            ),
+            attributes=None,
         )
 
     @override
@@ -111,9 +122,9 @@ class NullTelemetry(Telemetry):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> UpDownCounter:
+    ) -> TelemetryUpDownCounter:
         """
-        Get a up_down_counter metric
+        Get an up_down_counter metric
 
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
@@ -121,11 +132,13 @@ class NullTelemetry(Telemetry):
         :param attributes: Optional attributes
         :return: The Counter metric
         """
-
-        return NoOpUpDownCounter(
-            name=name,
-            unit=unit,
-            description=description,
+        return TelemetryUpDownCounter(
+            counter=NoOpUpDownCounter(
+                name=name,
+                unit=unit,
+                description=description,
+            ),
+            attributes=None,
         )
 
     @override
@@ -136,7 +149,7 @@ class NullTelemetry(Telemetry):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Histogram:
+    ) -> TelemetryHistogram:
         """
         Get a histograms metric
 
@@ -146,8 +159,11 @@ class NullTelemetry(Telemetry):
         :param attributes: Optional attributes
         :return: The Counter metric
         """
-        return NoOpHistogram(
-            name=name,
-            unit=unit,
-            description=description,
+        return TelemetryHistogram(
+            histogram=NoOpHistogram(
+                name=name,
+                unit=unit,
+                description=description,
+            ),
+            attributes=None,
         )

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
@@ -557,6 +557,10 @@ class OpenTelemetry(Telemetry):
         :param attributes: Additional attributes
         :return: The Counter metric
         """
+
+        attributes = attributes or {}
+        attributes.update(self._metadata)
+
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
@@ -587,7 +591,7 @@ class OpenTelemetry(Telemetry):
         attributes: Optional[Dict[str, Any]] = None,
     ) -> UpDownCounter:
         """
-        Get a up_down_counter metric
+        Get an up_down_counter metric
 
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
@@ -595,6 +599,9 @@ class OpenTelemetry(Telemetry):
         :param attributes: Additional attributes
         :return: The Counter metric
         """
+        attributes = attributes or {}
+        attributes.update(self._metadata)
+
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
@@ -633,6 +640,9 @@ class OpenTelemetry(Telemetry):
         :param attributes: Additional attributes
         :return: The Counter metric
         """
+        attributes = attributes or {}
+        attributes.update(self._metadata)
+
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
@@ -116,15 +116,20 @@ class OpenTelemetry(Telemetry):
             "deployment.environment": telemetry_context.environment,
             "host.name": hostname,
             "instance.id": self._instance_id,
+            "instance.name": telemetry_context.instance_name,
         }
 
         if telemetry_context.attributes:
             self._metadata.update(telemetry_context.attributes)
 
         # Create a resource with service details
+        # from https://opentelemetry.io/docs/specs/semconv/resource/
         resource_attributes = {
             ResourceAttributes.SERVICE_NAME: telemetry_context.service_name,
             ResourceAttributes.DEPLOYMENT_ENVIRONMENT: telemetry_context.environment,
+            ResourceAttributes.SERVICE_INSTANCE_ID: telemetry_context.instance_name,
+            ResourceAttributes.SERVICE_NAMESPACE: telemetry_context.service_namespace,
+            ResourceAttributes.HOST_NAME: hostname,
         }
         image_version: Optional[str] = os.getenv("DOCKER_IMAGE_VERSION")
         if image_version:

--- a/spark_pipeline_framework/utilities/telemetry/telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry.py
@@ -1,9 +1,17 @@
 from abc import abstractmethod, ABC
 from contextlib import asynccontextmanager, contextmanager
-from opentelemetry.metrics import Counter, UpDownCounter, Histogram
 
 from typing import Optional, Dict, Any, AsyncIterator, Iterator
 
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
+    TelemetryCounter,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_counter import (
+    TelemetryHistogram,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
+    TelemetryUpDownCounter,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
     TelemetryParent,
 )
@@ -114,7 +122,7 @@ class Telemetry(ABC):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Counter:
+    ) -> TelemetryCounter:
         """
         Get a counter metric
 
@@ -134,9 +142,9 @@ class Telemetry(ABC):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> UpDownCounter:
+    ) -> TelemetryUpDownCounter:
         """
-        Get a up_down_counter metric
+        Get an up_down_counter metric
 
         :param name: Name of the up_down_counter
         :param unit: Unit of the up_down_counter
@@ -154,7 +162,7 @@ class Telemetry(ABC):
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Histogram:
+    ) -> TelemetryHistogram:
         """
         Get a histograms metric
 

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
@@ -19,6 +19,9 @@ class TelemetryContext(DataClassJsonMixin):
     service_name: str
     """ Service name for the telemetry context """
 
+    service_namespace: str
+    """ Service namespace for the telemetry context.  Included in traces and metrics """
+
     instance_name: str
     """ Instance name for the telemetry context.  Included in traces and metrics """
 
@@ -62,6 +65,7 @@ class TelemetryContext(DataClassJsonMixin):
             attributes=None,
             log_level=None,
             instance_name="",
+            service_namespace="",
         )
 
     def copy(self) -> "TelemetryContext":
@@ -80,6 +84,7 @@ class TelemetryContext(DataClassJsonMixin):
             attributes=self.attributes,
             log_level=self.log_level,
             instance_name=self.instance_name,
+            service_namespace=self.service_namespace,
         )
 
     def create_child_context(

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
@@ -19,6 +19,9 @@ class TelemetryContext(DataClassJsonMixin):
     service_name: str
     """ Service name for the telemetry context """
 
+    instance_name: str
+    """ Instance name for the telemetry context.  Included in traces and metrics """
+
     environment: str
     """ Environment for the telemetry context """
 
@@ -58,6 +61,7 @@ class TelemetryContext(DataClassJsonMixin):
             environment="",
             attributes=None,
             log_level=None,
+            instance_name="",
         )
 
     def copy(self) -> "TelemetryContext":
@@ -75,6 +79,7 @@ class TelemetryContext(DataClassJsonMixin):
             trace_all_calls=self.trace_all_calls,
             attributes=self.attributes,
             log_level=self.log_level,
+            instance_name=self.instance_name,
         )
 
     def create_child_context(

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -3,9 +3,17 @@ from contextlib import asynccontextmanager, contextmanager
 from logging import Logger
 from typing import Optional, Dict, Any, AsyncGenerator, Generator
 
-from opentelemetry.metrics import UpDownCounter, Histogram, Counter
 
 from spark_pipeline_framework.logger.yarn_logger import get_logger
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
+    TelemetryCounter,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_counter import (
+    TelemetryHistogram,
+)
+from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
+    TelemetryUpDownCounter,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
@@ -138,7 +146,7 @@ class TelemetrySpanCreator:
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Counter:
+    ) -> TelemetryCounter:
         """
         Get a counter metric
 
@@ -159,7 +167,7 @@ class TelemetrySpanCreator:
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> UpDownCounter:
+    ) -> TelemetryUpDownCounter:
         """
         Get an up_down_counter metric
 
@@ -169,7 +177,7 @@ class TelemetrySpanCreator:
         :param attributes: Optional attributes
         :return: The Counter metric
         """
-        return self.get_up_down_counter(
+        return self.telemetry.get_up_down_counter(
             name=name, unit=unit, description=description, attributes=attributes
         )
 
@@ -180,7 +188,7 @@ class TelemetrySpanCreator:
         unit: str,
         description: str,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> Histogram:
+    ) -> TelemetryHistogram:
         """
         Get a histograms metric
 

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -1,13 +1,9 @@
 import uuid
 from contextlib import asynccontextmanager, contextmanager
 from logging import Logger
-from typing import (
-    Optional,
-    Dict,
-    Any,
-    AsyncGenerator,
-    Generator,
-)
+from typing import Optional, Dict, Any, AsyncGenerator, Generator
+
+from opentelemetry.metrics import UpDownCounter, Histogram, Counter
 
 from spark_pipeline_framework.logger.yarn_logger import get_logger
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
@@ -134,3 +130,66 @@ class TelemetrySpanCreator:
         """
         if self.telemetry:
             await self.telemetry.flush_async()
+
+    def get_counter(
+        self,
+        *,
+        name: str,
+        unit: str,
+        description: str,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> Counter:
+        """
+        Get a counter metric
+
+        :param name: Name of the counter
+        :param unit: Unit of the counter
+        :param description: Description
+        :param attributes: Optional attributes
+        :return: The Counter metric
+        """
+        return self.telemetry.get_counter(
+            name=name, unit=unit, description=description, attributes=attributes
+        )
+
+    def get_up_down_counter(
+        self,
+        *,
+        name: str,
+        unit: str,
+        description: str,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> UpDownCounter:
+        """
+        Get an up_down_counter metric
+
+        :param name: Name of the up_down_counter
+        :param unit: Unit of the up_down_counter
+        :param description: Description
+        :param attributes: Optional attributes
+        :return: The Counter metric
+        """
+        return self.get_up_down_counter(
+            name=name, unit=unit, description=description, attributes=attributes
+        )
+
+    def get_histogram(
+        self,
+        *,
+        name: str,
+        unit: str,
+        description: str,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> Histogram:
+        """
+        Get a histograms metric
+
+        :param name: Name of the histograms
+        :param unit: Unit of the histograms
+        :param description: Description
+        :param attributes: Optional attributes
+        :return: The Counter metric
+        """
+        return self.telemetry.get_histogram(
+            name=name, unit=unit, description=description, attributes=attributes
+        )

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
@@ -22,6 +22,7 @@ async def test_open_telemetry_async() -> None:
         environment="development",
         attributes=None,
         log_level=None,
+        instance_name="main-operation",
     )
     telemetry = OpenTelemetry(telemetry_context=telemetry_context, log_level="DEBUG")
 

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry.py
@@ -23,6 +23,7 @@ async def test_open_telemetry_async() -> None:
         attributes=None,
         log_level=None,
         instance_name="main-operation",
+        service_namespace="MyNamespace",
     )
     telemetry = OpenTelemetry(telemetry_context=telemetry_context, log_level="DEBUG")
 

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
@@ -91,6 +91,7 @@ async def run_sub_operation(
         attributes=None,
         log_level=None,
         instance_name="sub-operation",
+        service_namespace="MyNamespace",
     )
     telemetry = OpenTelemetry(
         telemetry_context=telemetry_context,
@@ -120,6 +121,7 @@ async def test_open_telemetry_multi_thread() -> None:
         attributes=None,
         log_level=None,
         instance_name="main-operation",
+        service_namespace="MyNamespace",
     )
     telemetry = OpenTelemetry(
         telemetry_context=telemetry_context,

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
@@ -90,6 +90,7 @@ async def run_sub_operation(
         provider=TelemetryProvider.OPEN_TELEMETRY,
         attributes=None,
         log_level=None,
+        instance_name="sub-operation",
     )
     telemetry = OpenTelemetry(
         telemetry_context=telemetry_context,
@@ -118,6 +119,7 @@ async def test_open_telemetry_multi_thread() -> None:
         provider=TelemetryProvider.OPEN_TELEMETRY,
         attributes=None,
         log_level=None,
+        instance_name="main-operation",
     )
     telemetry = OpenTelemetry(
         telemetry_context=telemetry_context,


### PR DESCRIPTION
1. Telemetry Improvements
   - This PR introduces a new set of wrapper classes for OpenTelemetry metrics: `TelemetryCounter`, `TelemetryUpDownCounter`, and `TelemetryHistogram`
   - These wrappers allow for consistent attribute handling across different metric types
   - The changes add support for automatically including metadata attributes in metrics

2. Environment and Telemetry Context Enhancements
   - Added `instance_name` and `service_namespace` to `TelemetryContext`
   - Updated resource attributes to include more semantic conventions from OpenTelemetry
   - Added environment variables `OTEL_INSTANCE_NAME` and `OTEL_SERVICE_NAMESPACE` with fallback values

3. Code Structure
   - Created a new `metrics` subdirectory under `telemetry` to organize the new metric wrapper classes
   - Updated multiple files to use the new metric wrapper classes consistently
