### PR TITLE
inherit attributes from parent span

### DIFF
--- a/spark_pipeline_framework/mixins/loop_id_mixin.py
+++ b/spark_pipeline_framework/mixins/loop_id_mixin.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+
+class LoopIdMixin:
+    def __init__(self) -> None:
+        self.loop_id: Optional[str] = None
+
+    def set_loop_id(self, loop_id: Optional[str]) -> None:
+        """
+        Set when running inside a FrameworkLoopTransformer
+
+        :param loop_id: loop id
+        """
+        self.loop_id = loop_id

--- a/spark_pipeline_framework/mixins/telemetry_parent_mixin.py
+++ b/spark_pipeline_framework/mixins/telemetry_parent_mixin.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
+)
+
+
+class TelemetryParentMixin:
+    def __init__(self) -> None:
+        self.telemetry_parent: Optional[TelemetryParent] = None
+
+    def set_telemetry_parent(
+        self, *, telemetry_parent: Optional[TelemetryParent]
+    ) -> None:
+        self.telemetry_parent = telemetry_parent

--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -53,6 +53,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
         telemetry_context: Optional[TelemetryContext] = None,
         name: Optional[str] = None,
         attributes: Optional[Dict[str, TelemetryAttributeValue]] = None,
+        telemetry_parent: Optional[TelemetryParent] = None,
     ) -> None:
         """
         Base class for all pipelines
@@ -73,35 +74,40 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
             os.environ.get("TELEMETRY_ENABLE")
         )
 
-        self.set_telemetry_parent(
-            telemetry_parent=TelemetryParent(
-                name=name or self.__class__.__qualname__,
-                trace_id=None,
-                span_id=None,
-                telemetry_context=(
-                    telemetry_context
-                    or TelemetryContext(
-                        provider=(
-                            TelemetryProvider.OPEN_TELEMETRY
-                            if self.telemetry_enable
-                            else TelemetryProvider.NULL
-                        ),
-                        service_name=os.getenv("OTEL_SERVICE_NAME", "helix-pipelines"),
-                        environment=os.getenv("ENV", "development"),
-                        attributes=attributes,
-                        log_level=log_level,
-                        instance_name=os.getenv(
-                            "OTEL_INSTANCE_NAME",
-                            self.parameters.get("flow_run_name", "unknown"),
-                        ),
-                        service_namespace=os.getenv(
-                            "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
-                        ),
-                    )
-                ),
-                attributes=attributes,
+        if telemetry_parent:
+            self.telemetry_parent = telemetry_parent
+        else:
+            self.set_telemetry_parent(
+                telemetry_parent=TelemetryParent(
+                    name=name or self.__class__.__qualname__,
+                    trace_id=None,
+                    span_id=None,
+                    telemetry_context=(
+                        telemetry_context
+                        or TelemetryContext(
+                            provider=(
+                                TelemetryProvider.OPEN_TELEMETRY
+                                if self.telemetry_enable
+                                else TelemetryProvider.NULL
+                            ),
+                            service_name=os.getenv(
+                                "OTEL_SERVICE_NAME", "helix-pipelines"
+                            ),
+                            environment=os.getenv("ENV", "development"),
+                            attributes=attributes,
+                            log_level=log_level,
+                            instance_name=os.getenv(
+                                "OTEL_INSTANCE_NAME",
+                                self.parameters.get("flow_run_name", "unknown"),
+                            ),
+                            service_namespace=os.getenv(
+                                "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
+                            ),
+                        )
+                    ),
+                    attributes=attributes,
+                )
             )
-        )
 
         self.name: Optional[str] = name
         self.attributes: Optional[Dict[str, Any]] = attributes

--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -143,7 +143,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
         ).create_telemetry_span_creator(log_level=self.log_level)
 
         telemetry_span: TelemetrySpanWrapper
-        async with telemetry_span_creator.create_telemetry_span(
+        async with telemetry_span_creator.create_telemetry_span_async(
             name=self.name or self.__class__.__qualname__,
             attributes=self.attributes,
             telemetry_parent=self.telemetry_parent,
@@ -176,7 +176,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
                     stage_name = transformer.__class__.__name__
 
                 transformer_span: TelemetrySpanWrapper
-                async with telemetry_span_creator.create_telemetry_span(
+                async with telemetry_span_creator.create_telemetry_span_async(
                     name=stage_name,
                     attributes={
                         "loop_id": self.loop_id,

--- a/spark_pipeline_framework/pipelines/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/framework_pipeline.py
@@ -135,7 +135,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
 
         telemetry_span: TelemetrySpanWrapper
         async with telemetry_span_creator.create_telemetry_span(
-            name=self.name or "framework_pipeline",
+            name=self.name or self.__class__.__qualname__,
             attributes={
                 "run_id": self._run_id,
             }

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -69,6 +69,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
         telemetry_context: Optional[TelemetryContext] = None,
         name: Optional[str] = None,
         attributes: Optional[Dict[str, TelemetryAttributeValue]] = None,
+        telemetry_parent: Optional[TelemetryParent] = None,
     ) -> None:
         """
         Base class for all pipelines
@@ -104,35 +105,40 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
             os.environ.get("TELEMETRY_ENABLE")
         )
 
-        self.set_telemetry_parent(
-            telemetry_parent=TelemetryParent(
-                name=name or self.__class__.__qualname__,
-                trace_id=None,
-                span_id=None,
-                telemetry_context=(
-                    telemetry_context
-                    or TelemetryContext(
-                        provider=(
-                            TelemetryProvider.OPEN_TELEMETRY
-                            if self.telemetry_enable
-                            else TelemetryProvider.NULL
-                        ),
-                        service_name=os.getenv("OTEL_SERVICE_NAME", "helix-pipelines"),
-                        environment=os.getenv("ENV", "development"),
-                        attributes=attributes,
-                        log_level=log_level,
-                        instance_name=os.getenv(
-                            "OTEL_INSTANCE_NAME",
-                            self.parameters.get("flow_run_name", "unknown"),
-                        ),
-                        service_namespace=os.getenv(
-                            "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
-                        ),
-                    )
-                ),
-                attributes=attributes,
+        if telemetry_parent:
+            self.telemetry_parent = telemetry_parent
+        else:
+            self.set_telemetry_parent(
+                telemetry_parent=TelemetryParent(
+                    name=name or self.__class__.__qualname__,
+                    trace_id=None,
+                    span_id=None,
+                    telemetry_context=(
+                        telemetry_context
+                        or TelemetryContext(
+                            provider=(
+                                TelemetryProvider.OPEN_TELEMETRY
+                                if self.telemetry_enable
+                                else TelemetryProvider.NULL
+                            ),
+                            service_name=os.getenv(
+                                "OTEL_SERVICE_NAME", "helix-pipelines"
+                            ),
+                            environment=os.getenv("ENV", "development"),
+                            attributes=attributes,
+                            log_level=log_level,
+                            instance_name=os.getenv(
+                                "OTEL_INSTANCE_NAME",
+                                self.parameters.get("flow_run_name", "unknown"),
+                            ),
+                            service_namespace=os.getenv(
+                                "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
+                            ),
+                        )
+                    ),
+                    attributes=attributes,
+                )
             )
-        )
 
         self.name: Optional[str] = name
         self.attributes: Optional[Dict[str, Any]] = attributes

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -170,7 +170,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
 
         telemetry_span: TelemetrySpanWrapper
         async with telemetry_span_creator.create_telemetry_span(
-            name=self.name or "framework_pipeline",
+            name=self.name or self.__class__.__qualname__,
             attributes={
                 "run_id": self._run_id,
             }

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -178,7 +178,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
         ).create_telemetry_span_creator(log_level=self.log_level)
 
         telemetry_span: TelemetrySpanWrapper
-        async with telemetry_span_creator.create_telemetry_span(
+        async with telemetry_span_creator.create_telemetry_span_async(
             name=self.name or self.__class__.__qualname__,
             attributes=self.attributes,
             telemetry_parent=self.telemetry_parent,
@@ -212,7 +212,7 @@ class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
                         stage_name = transformer.__class__.__name__
 
                     transformer_span: TelemetrySpanWrapper
-                    async with telemetry_span_creator.create_telemetry_span(
+                    async with telemetry_span_creator.create_telemetry_span_async(
                         name=stage_name,
                         attributes={
                             "loop_id": self.loop_id,

--- a/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
+++ b/spark_pipeline_framework/pipelines/v2/framework_pipeline.py
@@ -8,6 +8,8 @@ from pyspark.ml.base import Transformer
 from pyspark.sql.dataframe import DataFrame
 
 from spark_pipeline_framework.logger.log_level import LogLevel
+from spark_pipeline_framework.mixins.loop_id_mixin import LoopIdMixin
+from spark_pipeline_framework.mixins.telemetry_parent_mixin import TelemetryParentMixin
 from spark_pipeline_framework.transformers.framework_csv_exporter.v1.framework_csv_exporter import (
     FrameworkCsvExporter,
 )
@@ -29,11 +31,17 @@ from spark_pipeline_framework.utilities.pipeline_helper import create_steps
 from spark_pipeline_framework.utilities.spark_data_frame_helpers import (
     spark_list_catalog_table_names,
 )
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_factory import (
     TelemetryFactory,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_provider import (
     TelemetryProvider,
@@ -46,7 +54,7 @@ from spark_pipeline_framework.utilities.telemetry.telemetry_span_wrapper import 
 )
 
 
-class FrameworkPipeline(Transformer):
+class FrameworkPipeline(Transformer, LoopIdMixin, TelemetryParentMixin):
     def __init__(
         self,
         parameters: Dict[str, Any],
@@ -60,7 +68,7 @@ class FrameworkPipeline(Transformer):
         telemetry_enable: Optional[bool] = None,
         telemetry_context: Optional[TelemetryContext] = None,
         name: Optional[str] = None,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Dict[str, TelemetryAttributeValue]] = None,
     ) -> None:
         """
         Base class for all pipelines
@@ -96,27 +104,33 @@ class FrameworkPipeline(Transformer):
             os.environ.get("TELEMETRY_ENABLE")
         )
 
-        self.telemetry_context: TelemetryContext = (
-            telemetry_context
-            or TelemetryContext(
-                provider=(
-                    TelemetryProvider.OPEN_TELEMETRY
-                    if self.telemetry_enable
-                    else TelemetryProvider.NULL
-                ),
+        self.set_telemetry_parent(
+            telemetry_parent=TelemetryParent(
+                name=name or self.__class__.__qualname__,
                 trace_id=None,
                 span_id=None,
-                service_name=os.getenv("OTEL_SERVICE_NAME", "helix-pipelines"),
-                environment=os.getenv("ENV", "development"),
+                telemetry_context=(
+                    telemetry_context
+                    or TelemetryContext(
+                        provider=(
+                            TelemetryProvider.OPEN_TELEMETRY
+                            if self.telemetry_enable
+                            else TelemetryProvider.NULL
+                        ),
+                        service_name=os.getenv("OTEL_SERVICE_NAME", "helix-pipelines"),
+                        environment=os.getenv("ENV", "development"),
+                        attributes=attributes,
+                        log_level=log_level,
+                        instance_name=os.getenv(
+                            "OTEL_INSTANCE_NAME",
+                            self.parameters.get("flow_run_name", "unknown"),
+                        ),
+                        service_namespace=os.getenv(
+                            "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
+                        ),
+                    )
+                ),
                 attributes=attributes,
-                log_level=log_level,
-                instance_name=os.getenv(
-                    "OTEL_INSTANCE_NAME",
-                    self.parameters.get("flow_run_name", "unknown"),
-                ),
-                service_namespace=os.getenv(
-                    "OTEL_SERVICE_NAMESPACE", "helix-pipelines"
-                ),
             )
         )
 
@@ -151,7 +165,7 @@ class FrameworkPipeline(Transformer):
 
         """
         telemetry_span_creator: TelemetrySpanCreator = TelemetryFactory(
-            telemetry_context=self.telemetry_context
+            telemetry_parent=self.telemetry_parent or TelemetryParent.get_null_parent()
         ).create_telemetry_span_creator(log_level=self.log_level)
 
         telemetry_span: TelemetrySpanWrapper
@@ -161,12 +175,10 @@ class FrameworkPipeline(Transformer):
                 "run_id": self._run_id,
             }
             | (self.attributes or {}),
+            telemetry_parent=self.telemetry_parent,
         ) as telemetry_span:
             # set the trace and span ids in the telemetry context so even if Telemetry
             # is done from multiple spark nodes they should all show up under the same span
-            child_telemetry_context: TelemetryContext = (
-                telemetry_span.create_child_telemetry_context()
-            )
             try:
                 # if steps are defined but not transformers then convert steps to transformers first
                 if len(self.steps) > 0 and len(self.transformers) == 0:
@@ -209,13 +221,13 @@ class FrameworkPipeline(Transformer):
                                 f"---- Running pipeline [{pipeline_name}] transformer [{stage_name}]  "
                                 f"({i} of {count_of_transformers}) ----"
                             )
-                            if hasattr(transformer, "set_loop_id"):
+                            if isinstance(transformer, LoopIdMixin):
                                 transformer.set_loop_id(self.loop_id)
-
-                            if hasattr(transformer, "set_telemetry_context"):
-                                transformer.set_telemetry_context(
-                                    telemetry_context=transformer_span.create_child_telemetry_context()
+                            if isinstance(transformer, TelemetryParentMixin):
+                                transformer.set_telemetry_parent(
+                                    telemetry_parent=transformer_span.create_child_telemetry_parent()
                                 )
+
                             self.progress_logger.start_mlflow_run(
                                 run_name=stage_name, is_nested=True
                             )

--- a/spark_pipeline_framework/transformers/framework_if_else_transformer/v1/framework_if_else_transformer.py
+++ b/spark_pipeline_framework/transformers/framework_if_else_transformer/v1/framework_if_else_transformer.py
@@ -139,7 +139,7 @@ class FrameworkIfElseTransformer(FrameworkTransformer):
                 stage_name = stage.__class__.__name__
 
             telemetry_span: TelemetrySpanWrapper
-            async with telemetry_span_creator.create_telemetry_span(
+            async with telemetry_span_creator.create_telemetry_span_async(
                 name=stage_name, attributes={}, telemetry_parent=self.telemetry_parent
             ) as telemetry_span:
 

--- a/spark_pipeline_framework/transformers/framework_if_else_transformer/v1/framework_if_else_transformer.py
+++ b/spark_pipeline_framework/transformers/framework_if_else_transformer/v1/framework_if_else_transformer.py
@@ -1,6 +1,8 @@
 from os import environ
 from typing import Dict, Any, Optional, Union, List, Callable
 
+from spark_pipeline_framework.mixins.loop_id_mixin import LoopIdMixin
+from spark_pipeline_framework.mixins.telemetry_parent_mixin import TelemetryParentMixin
 from spark_pipeline_framework.utilities.capture_parameters import capture_parameters
 from pyspark.ml import Transformer
 from pyspark.sql.dataframe import DataFrame
@@ -9,11 +11,11 @@ from spark_pipeline_framework.progress_logger.progress_logger import ProgressLog
 from spark_pipeline_framework.transformers.framework_transformer.v1.framework_transformer import (
     FrameworkTransformer,
 )
-from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
-    TelemetryContext,
-)
 from spark_pipeline_framework.utilities.telemetry.telemetry_factory import (
     TelemetryFactory,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_span_creator import (
     TelemetrySpanCreator,
@@ -122,8 +124,7 @@ class FrameworkIfElseTransformer(FrameworkTransformer):
             )
 
         telemetry_span_creator: TelemetrySpanCreator = TelemetryFactory(
-            telemetry_context=self.telemetry_context
-            or TelemetryContext.get_null_context()
+            telemetry_parent=self.telemetry_parent or TelemetryParent.get_null_parent()
         ).create_telemetry_span_creator(log_level=environ.get("LOGLEVEL"))
 
         for stage in stages:
@@ -139,23 +140,18 @@ class FrameworkIfElseTransformer(FrameworkTransformer):
 
             telemetry_span: TelemetrySpanWrapper
             async with telemetry_span_creator.create_telemetry_span(
-                name=stage_name,
-                attributes={},
+                name=stage_name, attributes={}, telemetry_parent=self.telemetry_parent
             ) as telemetry_span:
-                child_telemetry_context = (
-                    telemetry_span.create_child_telemetry_context()
-                )
 
                 if progress_logger is not None:
                     progress_logger.start_mlflow_run(
                         run_name=stage_name, is_nested=True
                     )
-                if hasattr(stage, "set_loop_id"):
+                if isinstance(stage, LoopIdMixin):
                     stage.set_loop_id(self.loop_id)
-
-                if hasattr(stage, "set_telemetry_context"):
-                    stage.set_telemetry_context(
-                        telemetry_context=child_telemetry_context
+                if isinstance(stage, TelemetryParentMixin):
+                    stage.set_telemetry_parent(
+                        telemetry_parent=telemetry_span.create_child_telemetry_parent()
                     )
 
                 try:

--- a/spark_pipeline_framework/transformers/framework_loop_transformer/v1/framework_loop_transformer.py
+++ b/spark_pipeline_framework/transformers/framework_loop_transformer/v1/framework_loop_transformer.py
@@ -128,7 +128,7 @@ class FrameworkLoopTransformer(FrameworkTransformer):
                     stage_name = stage.__class__.__name__
 
                 telemetry_span: TelemetrySpanWrapper
-                async with telemetry_span_creator.create_telemetry_span(
+                async with telemetry_span_creator.create_telemetry_span_async(
                     name=stage_name,
                     attributes={
                         "loop_id": str(current_run_number),

--- a/spark_pipeline_framework/transformers/framework_parallel_executor/v1/framework_parallel_executor.py
+++ b/spark_pipeline_framework/transformers/framework_parallel_executor/v1/framework_parallel_executor.py
@@ -110,7 +110,7 @@ class FrameworkParallelExecutor(FrameworkTransformer):
                         self._process_async(df, stages, progress_logger=progress_logger)
                     )
                 else:
-                    self._process_sync(df, stages, progress_logger=progress_logger)
+                    self._process(df, stages, progress_logger=progress_logger)
         else:
             if progress_logger is not None:
                 progress_logger.write_to_log(
@@ -150,7 +150,7 @@ class FrameworkParallelExecutor(FrameworkTransformer):
             )
 
             telemetry_span: TelemetrySpanWrapper
-            async with telemetry_span_creator.create_telemetry_span(
+            async with telemetry_span_creator.create_telemetry_span_async(
                 name=stage_name,
                 attributes={},
                 telemetry_parent=self.telemetry_parent,
@@ -174,7 +174,7 @@ class FrameworkParallelExecutor(FrameworkTransformer):
         df = create_empty_dataframe(df.sparkSession)
 
         async for name, _ in pipeline_executor.transform_async(df, df.sparkSession):
-            async with telemetry_span_creator.create_telemetry_span(
+            async with telemetry_span_creator.create_telemetry_span_async(
                 name=name,
                 attributes={},
                 telemetry_parent=telemetry_span.create_child_telemetry_parent(),
@@ -184,7 +184,7 @@ class FrameworkParallelExecutor(FrameworkTransformer):
 
         logger.info("Finished process_async")
 
-    def _process_sync(
+    def _process(
         self,
         df: DataFrame,
         stages: List[Transformer],

--- a/spark_pipeline_framework/transformers/framework_parallel_executor/v1/framework_parallel_executor.py
+++ b/spark_pipeline_framework/transformers/framework_parallel_executor/v1/framework_parallel_executor.py
@@ -2,6 +2,8 @@ import json
 from os import environ
 from typing import Dict, Any, Optional, Union, List, Callable
 
+from spark_pipeline_framework.mixins.loop_id_mixin import LoopIdMixin
+from spark_pipeline_framework.mixins.telemetry_parent_mixin import TelemetryParentMixin
 from spark_pipeline_framework.utilities.async_helper.v1.async_helper import AsyncHelper
 
 # noinspection PyProtectedMember
@@ -19,11 +21,11 @@ from spark_pipeline_framework.utilities.parallel_pipeline_executor.v1.parallel_p
 from spark_pipeline_framework.utilities.spark_data_frame_helpers import (
     create_empty_dataframe,
 )
-from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
-    TelemetryContext,
-)
 from spark_pipeline_framework.utilities.telemetry.telemetry_factory import (
     TelemetryFactory,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_span_creator import (
     TelemetrySpanCreator,
@@ -139,8 +141,7 @@ class FrameworkParallelExecutor(FrameworkTransformer):
         )
 
         telemetry_span_creator: TelemetrySpanCreator = TelemetryFactory(
-            telemetry_context=self.telemetry_context
-            or TelemetryContext.get_null_context()
+            telemetry_parent=self.telemetry_parent or TelemetryParent.get_null_parent()
         ).create_telemetry_span_creator(log_level=environ.get("LOGLEVEL"))
 
         for stage in stages:
@@ -152,13 +153,14 @@ class FrameworkParallelExecutor(FrameworkTransformer):
             async with telemetry_span_creator.create_telemetry_span(
                 name=stage_name,
                 attributes={},
+                telemetry_parent=self.telemetry_parent,
             ) as telemetry_span:
 
-                if hasattr(stage, "set_loop_id"):
+                if isinstance(stage, LoopIdMixin):
                     stage.set_loop_id(self.loop_id)
-                if hasattr(stage, "set_telemetry_context"):
-                    stage.set_telemetry_context(
-                        telemetry_context=telemetry_span.create_child_telemetry_context()
+                if isinstance(stage, TelemetryParentMixin):
+                    stage.set_telemetry_parent(
+                        telemetry_parent=telemetry_span.create_child_telemetry_parent()
                     )
 
                 assert (
@@ -175,6 +177,7 @@ class FrameworkParallelExecutor(FrameworkTransformer):
             async with telemetry_span_creator.create_telemetry_span(
                 name=name,
                 attributes={},
+                telemetry_parent=telemetry_span.create_child_telemetry_parent(),
             ) as telemetry_span:
                 if name:
                     logger.info(f"Finished running parallel stage {name}")
@@ -200,11 +203,10 @@ class FrameworkParallelExecutor(FrameworkTransformer):
             stage_name: str = (
                 stage.getName() if hasattr(stage, "getName") else "Unknown Transformer"
             )
-            if hasattr(stage, "set_loop_id"):
+            if isinstance(stage, LoopIdMixin):
                 stage.set_loop_id(self.loop_id)
-            if hasattr(stage, "set_telemetry_context"):
-                stage.set_telemetry_context(telemetry_context=self.telemetry_context)
-
+            if isinstance(stage, TelemetryParentMixin):
+                stage.set_telemetry_parent(telemetry_parent=self.telemetry_parent)
             assert (
                 stage_name
             ), f"name must be set on every transformer in FrameworkParallelExecutor: f{json.dumps(stage, default=str)}"

--- a/spark_pipeline_framework/transformers/framework_transformer/v1/framework_transformer.py
+++ b/spark_pipeline_framework/transformers/framework_transformer/v1/framework_transformer.py
@@ -12,11 +12,13 @@ from pyspark.sql.dataframe import DataFrame
 from typing_extensions import final
 
 from spark_pipeline_framework.logger.yarn_logger import get_logger
+from spark_pipeline_framework.mixins.loop_id_mixin import LoopIdMixin
+from spark_pipeline_framework.mixins.telemetry_parent_mixin import TelemetryParentMixin
 from spark_pipeline_framework.progress_logger.progress_logger import ProgressLogger
 from spark_pipeline_framework.utilities.async_helper.v1.async_helper import AsyncHelper
 from spark_pipeline_framework.utilities.class_helpers import ClassHelpers
-from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
-    TelemetryContext,
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
 )
 
 
@@ -24,6 +26,8 @@ class FrameworkTransformer(
     Transformer,
     DefaultParamsReadable,  # type: ignore
     DefaultParamsWritable,
+    LoopIdMixin,
+    TelemetryParentMixin,
 ):
     def __init__(
         self,
@@ -51,7 +55,7 @@ class FrameworkTransformer(
 
         self.loop_id: Optional[str] = None
 
-        self.telemetry_context: Optional[TelemetryContext] = None
+        self.telemetry_parent: Optional[TelemetryParent] = None
 
         self.parameters: Optional[Dict[str, Any]] = parameters
 
@@ -146,17 +150,6 @@ class FrameworkTransformer(
             for key, value in dictionary.items():
                 setattr(self, key, value)
         return self
-
-    def set_loop_id(self, loop_id: str) -> None:
-        """
-        Set when running inside a FrameworkLoopTransformer
-
-        :param loop_id: loop id
-        """
-        self.loop_id = loop_id
-
-    def set_telemetry_context(self, telemetry_context: TelemetryContext) -> None:
-        self.telemetry_context = telemetry_context
 
     async def transform_async(self, df: DataFrame) -> DataFrame:
         """

--- a/spark_pipeline_framework/transformers/framework_transformer_group/v1/framework_transformer_group.py
+++ b/spark_pipeline_framework/transformers/framework_transformer_group/v1/framework_transformer_group.py
@@ -1,6 +1,9 @@
 from os import environ
 from typing import Dict, Any, Optional, Union, List, Callable
 
+from spark_pipeline_framework.mixins.loop_id_mixin import LoopIdMixin
+from spark_pipeline_framework.mixins.telemetry_parent_mixin import TelemetryParentMixin
+
 # noinspection PyProtectedMember
 from spark_pipeline_framework.utilities.capture_parameters import capture_parameters
 from pyspark.ml import Transformer
@@ -10,11 +13,11 @@ from spark_pipeline_framework.progress_logger.progress_logger import ProgressLog
 from spark_pipeline_framework.transformers.framework_transformer.v1.framework_transformer import (
     FrameworkTransformer,
 )
-from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
-    TelemetryContext,
-)
 from spark_pipeline_framework.utilities.telemetry.telemetry_factory import (
     TelemetryFactory,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_span_creator import (
     TelemetrySpanCreator,
@@ -79,8 +82,7 @@ class FrameworkTransformerGroup(FrameworkTransformer):
         )
 
         telemetry_span_creator: TelemetrySpanCreator = TelemetryFactory(
-            telemetry_context=self.telemetry_context
-            or TelemetryContext.get_null_context()
+            telemetry_parent=self.telemetry_parent or TelemetryParent.get_null_parent()
         ).create_telemetry_span_creator(log_level=environ.get("LOGLEVEL"))
 
         if (enable or enable is None) and enable_if_view_not_empty:
@@ -98,20 +100,18 @@ class FrameworkTransformerGroup(FrameworkTransformer):
                 async with telemetry_span_creator.create_telemetry_span(
                     name=stage_name,
                     attributes={},
+                    telemetry_parent=self.telemetry_parent,
                 ) as telemetry_span:
-                    child_telemetry_context = (
-                        telemetry_span.create_child_telemetry_context()
-                    )
-
                     if progress_logger is not None:
                         progress_logger.start_mlflow_run(
                             run_name=stage_name, is_nested=True
                         )
-                    if hasattr(stage, "set_loop_id"):
+
+                    if isinstance(stage, LoopIdMixin):
                         stage.set_loop_id(self.loop_id)
-                    if hasattr(stage, "set_telemetry_context"):
-                        stage.set_telemetry_context(
-                            telemetry_context=child_telemetry_context
+                    if isinstance(stage, TelemetryParentMixin):
+                        stage.set_telemetry_parent(
+                            telemetry_parent=telemetry_span.create_child_telemetry_parent()
                         )
 
                     try:

--- a/spark_pipeline_framework/transformers/framework_transformer_group/v1/framework_transformer_group.py
+++ b/spark_pipeline_framework/transformers/framework_transformer_group/v1/framework_transformer_group.py
@@ -97,7 +97,7 @@ class FrameworkTransformerGroup(FrameworkTransformer):
                     stage_name = stage.__class__.__name__
 
                 telemetry_span: TelemetrySpanWrapper
-                async with telemetry_span_creator.create_telemetry_span(
+                async with telemetry_span_creator.create_telemetry_span_async(
                     name=stage_name,
                     attributes={},
                     telemetry_parent=self.telemetry_parent,

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
@@ -103,7 +103,10 @@ class ConsoleTelemetry(Telemetry):
         # if parent is still None then create a new trace_id and span_id
         if telemetry_parent is None:
             telemetry_parent = TelemetryParent(
-                trace_id=str(uuid.uuid4()), span_id=str(uuid.uuid4()), name=name
+                trace_id=str(uuid.uuid4()),
+                span_id=str(uuid.uuid4()),
+                name=name,
+                attributes=attributes,
             )
 
         token: Token[TelemetryParent | None] | None = (
@@ -149,7 +152,10 @@ class ConsoleTelemetry(Telemetry):
         # if parent is still None then create a new trace_id and span_id
         if telemetry_parent is None:
             telemetry_parent = TelemetryParent(
-                trace_id=str(uuid.uuid4()), span_id=str(uuid.uuid4()), name=name
+                trace_id=str(uuid.uuid4()),
+                span_id=str(uuid.uuid4()),
+                name=name,
+                attributes=attributes,
             )
 
         token: Token[TelemetryParent | None] | None = (
@@ -207,6 +213,7 @@ class ConsoleTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryCounter:
         """
@@ -216,6 +223,7 @@ class ConsoleTelemetry(Telemetry):
         :param unit: Unit of the counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return TelemetryCounter(
@@ -224,7 +232,8 @@ class ConsoleTelemetry(Telemetry):
                 unit=unit,
                 description=description,
             ),
-            attributes=None,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )
 
     @override
@@ -234,6 +243,7 @@ class ConsoleTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryUpDownCounter:
         """
@@ -243,6 +253,7 @@ class ConsoleTelemetry(Telemetry):
         :param unit: Unit of the up_down_counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return TelemetryUpDownCounter(
@@ -251,7 +262,8 @@ class ConsoleTelemetry(Telemetry):
                 unit=unit,
                 description=description,
             ),
-            attributes=None,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )
 
     @override
@@ -261,6 +273,7 @@ class ConsoleTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryHistogram:
         """
@@ -270,6 +283,7 @@ class ConsoleTelemetry(Telemetry):
         :param unit: Unit of the histograms
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return TelemetryHistogram(
@@ -278,5 +292,6 @@ class ConsoleTelemetry(Telemetry):
                 unit=unit,
                 description=description,
             ),
-            attributes=None,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
@@ -78,12 +78,6 @@ class ConsoleTelemetry(Telemetry):
     def add_telemetry_history_item(
         cls, *, parent: TelemetryParent | None, item: ConsoleTelemetryHistoryItem
     ) -> None:
-        if parent is not None:
-            # check if we have the parent in the history
-            for history_item in cls._telemetry_history:
-                if history_item.matches(parent):
-                    history_item.children.append(item)
-                    return
         # otherwise add it to the root
         cls._telemetry_history.append(item)
 
@@ -111,6 +105,7 @@ class ConsoleTelemetry(Telemetry):
                 span_id=str(uuid.uuid4()),
                 name=name,
                 attributes=attributes,
+                telemetry_context=self._telemetry_context,
             )
 
         token: Token[TelemetryParent | None] | None = (
@@ -160,6 +155,7 @@ class ConsoleTelemetry(Telemetry):
                 span_id=str(uuid.uuid4()),
                 name=name,
                 attributes=attributes,
+                telemetry_context=self._telemetry_context,
             )
 
         token: Token[TelemetryParent | None] | None = (

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
@@ -11,6 +11,7 @@ from typing import (
     AsyncIterator,
     List,
     Union,
+    Mapping,
 )
 
 from opentelemetry.metrics import NoOpCounter, NoOpUpDownCounter, NoOpHistogram
@@ -33,6 +34,9 @@ from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_coun
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry import (
     Telemetry,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
@@ -89,7 +93,7 @@ class ConsoleTelemetry(Telemetry):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> Iterator[TelemetrySpanWrapper]:
 
@@ -139,7 +143,7 @@ class ConsoleTelemetry(Telemetry):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> AsyncIterator[TelemetrySpanWrapper]:
         # read the current value of the context variable
@@ -214,7 +218,7 @@ class ConsoleTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryCounter:
         """
         Get a counter metric
@@ -244,7 +248,7 @@ class ConsoleTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryUpDownCounter:
         """
         Get an up_down_counter metric
@@ -274,7 +278,7 @@ class ConsoleTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryHistogram:
         """
         Get a histograms metric

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry.py
@@ -89,6 +89,7 @@ class ConsoleTelemetry(Telemetry):
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> Iterator[TelemetrySpanWrapper]:
 
         # read the current value of the context variable
@@ -140,6 +141,7 @@ class ConsoleTelemetry(Telemetry):
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> AsyncIterator[TelemetrySpanWrapper]:
         # read the current value of the context variable
         current_value: TelemetryParent | None = self._current_context_variable.get()

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry_history_item.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry_history_item.py
@@ -37,9 +37,3 @@ class ConsoleTelemetryHistoryItem(DataClassJsonMixin):
             name=name,
             telemetry_parent=telemetry_parent,
         )
-
-    def matches(self, other: "TelemetryParent") -> bool:
-        return (
-            self.context.trace_id == other.trace_id
-            and self.context.span_id == other.span_id
-        )

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
@@ -51,7 +51,6 @@ class ConsoleTelemetrySpanWrapper(TelemetrySpanWrapper):
         super().__init__(
             name=name,
             attributes=attributes,
-            telemetry_context=telemetry_context,
             telemetry_parent=telemetry_parent,
         )
 

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
@@ -3,8 +3,12 @@ from typing import (
     Dict,
     Any,
     override,
+    Mapping,
 )
 
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
@@ -40,7 +44,7 @@ class ConsoleTelemetrySpanWrapper(TelemetrySpanWrapper):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_context: Optional[TelemetryContext],
         telemetry_parent: Optional[TelemetryParent],
     ) -> None:

--- a/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/console_telemetry_span_wrapper.py
@@ -57,3 +57,7 @@ class ConsoleTelemetrySpanWrapper(TelemetrySpanWrapper):
     @override
     def set_attributes(self, attributes: Dict[str, Any]) -> None:
         pass
+
+    @override
+    def end(self, *, end_time: int) -> None:
+        pass

--- a/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_counter.py
+++ b/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_counter.py
@@ -3,6 +3,10 @@ from typing import Optional, Dict, Any, Union
 from opentelemetry.context import Context
 from opentelemetry.metrics import Counter
 
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
+)
+
 
 class TelemetryCounter:
     """
@@ -11,11 +15,16 @@ class TelemetryCounter:
     """
 
     def __init__(
-        self, *, counter: Counter, attributes: Optional[Dict[str, Any]]
+        self,
+        *,
+        counter: Counter,
+        attributes: Optional[Dict[str, Any]],
+        telemetry_parent: Optional[TelemetryParent],
     ) -> None:
         assert counter
         self._counter: Counter = counter
         self._attributes: Optional[Dict[str, Any]] = attributes
+        self._telemetry_parent: Optional[TelemetryParent] = telemetry_parent
 
     def add(
         self,
@@ -23,7 +32,10 @@ class TelemetryCounter:
         attributes: Optional[Dict[str, Any]] = None,
         context: Optional[Context] = None,
     ) -> None:
-        attributes = attributes or {}
-        attributes.update(self._attributes or {})
+        final_attributes = self._attributes or {}
+        if self._telemetry_parent and self._telemetry_parent.attributes:
+            final_attributes.update(self._telemetry_parent.attributes)
+        if attributes:
+            final_attributes.update(attributes)
 
-        self._counter.add(amount=amount, attributes=attributes, context=context)
+        self._counter.add(amount=amount, attributes=final_attributes, context=context)

--- a/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_counter.py
+++ b/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_counter.py
@@ -1,10 +1,17 @@
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Union, Mapping
 
 from opentelemetry.context import Context
 from opentelemetry.metrics import Counter
 
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+    TelemetryAttributeValueWithoutNone,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
     TelemetryParent,
+)
+from spark_pipeline_framework.utilities.telemetry.utilities.mapping_appender import (
+    append_mappings,
 )
 
 
@@ -18,24 +25,30 @@ class TelemetryCounter:
         self,
         *,
         counter: Counter,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_parent: Optional[TelemetryParent],
     ) -> None:
         assert counter
         self._counter: Counter = counter
-        self._attributes: Optional[Dict[str, Any]] = attributes
+        self._attributes: Optional[Mapping[str, TelemetryAttributeValue]] = attributes
         self._telemetry_parent: Optional[TelemetryParent] = telemetry_parent
 
     def add(
         self,
         amount: Union[int, float],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Dict[str, bool | str | bytes | int | float | None]] = None,
         context: Optional[Context] = None,
     ) -> None:
-        final_attributes = self._attributes or {}
-        if self._telemetry_parent and self._telemetry_parent.attributes:
-            final_attributes.update(self._telemetry_parent.attributes)
-        if attributes:
-            final_attributes.update(attributes)
+        combined_attributes: Mapping[str, TelemetryAttributeValueWithoutNone] = (
+            append_mappings(
+                [
+                    self._attributes,
+                    self._telemetry_parent.attributes if self._telemetry_parent else {},
+                    attributes,
+                ]
+            )
+        )
 
-        self._counter.add(amount=amount, attributes=final_attributes, context=context)
+        self._counter.add(
+            amount=amount, attributes=combined_attributes, context=context
+        )

--- a/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_histogram_counter.py
+++ b/spark_pipeline_framework/utilities/telemetry/metrics/telemetry_histogram_counter.py
@@ -1,10 +1,17 @@
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Union, Mapping
 
 from opentelemetry.context import Context
 from opentelemetry.metrics import Histogram
 
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+    TelemetryAttributeValueWithoutNone,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
     TelemetryParent,
+)
+from spark_pipeline_framework.utilities.telemetry.utilities.mapping_appender import (
+    append_mappings,
 )
 
 
@@ -18,26 +25,30 @@ class TelemetryHistogram:
         self,
         *,
         histogram: Histogram,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_parent: Optional[TelemetryParent],
     ) -> None:
         assert histogram
         self._histogram: Histogram = histogram
-        self._attributes: Optional[Dict[str, Any]] = attributes
+        self._attributes: Optional[Mapping[str, TelemetryAttributeValue]] = attributes
         self._telemetry_parent: Optional[TelemetryParent] = telemetry_parent
 
     def record(
         self,
         amount: Union[int, float],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         context: Optional[Context] = None,
     ) -> None:
-        final_attributes = self._attributes or {}
-        if self._telemetry_parent and self._telemetry_parent.attributes:
-            final_attributes.update(self._telemetry_parent.attributes)
-        if attributes:
-            final_attributes.update(attributes)
+        combined_attributes: Mapping[str, TelemetryAttributeValueWithoutNone] = (
+            append_mappings(
+                [
+                    self._attributes,
+                    self._telemetry_parent.attributes if self._telemetry_parent else {},
+                    attributes,
+                ]
+            )
+        )
 
         self._histogram.record(
-            amount=amount, attributes=final_attributes, context=context
+            amount=amount, attributes=combined_attributes, context=context
         )

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
@@ -94,6 +94,7 @@ class NullTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryCounter:
         """
@@ -103,6 +104,7 @@ class NullTelemetry(Telemetry):
         :param unit: Unit of the counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return TelemetryCounter(
@@ -111,7 +113,8 @@ class NullTelemetry(Telemetry):
                 unit=unit,
                 description=description,
             ),
-            attributes=None,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )
 
     @override
@@ -121,6 +124,7 @@ class NullTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryUpDownCounter:
         """
@@ -130,6 +134,7 @@ class NullTelemetry(Telemetry):
         :param unit: Unit of the up_down_counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return TelemetryUpDownCounter(
@@ -138,7 +143,8 @@ class NullTelemetry(Telemetry):
                 unit=unit,
                 description=description,
             ),
-            attributes=None,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )
 
     @override
@@ -148,6 +154,7 @@ class NullTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryHistogram:
         """
@@ -157,6 +164,7 @@ class NullTelemetry(Telemetry):
         :param unit: Unit of the histograms
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return TelemetryHistogram(
@@ -165,5 +173,6 @@ class NullTelemetry(Telemetry):
                 unit=unit,
                 description=description,
             ),
-            attributes=None,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
@@ -70,7 +70,6 @@ class NullTelemetry(Telemetry):
         yield NullTelemetrySpanWrapper(
             name=name,
             attributes=attributes,
-            telemetry_context=self._telemetry_context,
             telemetry_parent=telemetry_parent,
         )
 
@@ -86,7 +85,6 @@ class NullTelemetry(Telemetry):
         yield NullTelemetrySpanWrapper(
             name=name,
             attributes=attributes,
-            telemetry_context=self._telemetry_context,
             telemetry_parent=telemetry_parent,
         )
 

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
@@ -66,6 +66,7 @@ class NullTelemetry(Telemetry):
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> Iterator[TelemetrySpanWrapper]:
         yield NullTelemetrySpanWrapper(
             name=name,
@@ -81,6 +82,7 @@ class NullTelemetry(Telemetry):
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> AsyncIterator[TelemetrySpanWrapper]:
         yield NullTelemetrySpanWrapper(
             name=name,

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager, asynccontextmanager
-from typing import Optional, Dict, Any, Iterator, AsyncIterator, override
+from typing import Optional, Dict, Any, Iterator, AsyncIterator, override, Mapping
 
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
     TelemetryCounter,
@@ -9,6 +9,9 @@ from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_co
 )
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
     TelemetryUpDownCounter,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
@@ -61,7 +64,7 @@ class NullTelemetry(Telemetry):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> Iterator[TelemetrySpanWrapper]:
         yield NullTelemetrySpanWrapper(
@@ -77,7 +80,7 @@ class NullTelemetry(Telemetry):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> AsyncIterator[TelemetrySpanWrapper]:
         yield NullTelemetrySpanWrapper(
@@ -95,7 +98,7 @@ class NullTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryCounter:
         """
         Get a counter metric
@@ -125,7 +128,7 @@ class NullTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryUpDownCounter:
         """
         Get an up_down_counter metric
@@ -155,7 +158,7 @@ class NullTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryHistogram:
         """
         Get a histograms metric

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
@@ -3,8 +3,12 @@ from typing import (
     Dict,
     Any,
     override,
+    Mapping,
 )
 
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
@@ -38,7 +42,7 @@ class NullTelemetrySpanWrapper(TelemetrySpanWrapper):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_context: Optional[TelemetryContext],
         telemetry_parent: Optional[TelemetryParent],
     ) -> None:

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
@@ -51,3 +51,7 @@ class NullTelemetrySpanWrapper(TelemetrySpanWrapper):
     @override
     def set_attributes(self, attributes: Dict[str, Any]) -> None:
         pass
+
+    @override
+    def end(self, *, end_time: int) -> None:
+        pass

--- a/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/null_telemetry_span_wrapper.py
@@ -9,9 +9,6 @@ from typing import (
 from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
     TelemetryAttributeValue,
 )
-from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
-    TelemetryContext,
-)
 
 from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
     TelemetryParent,
@@ -43,13 +40,11 @@ class NullTelemetrySpanWrapper(TelemetrySpanWrapper):
         *,
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]],
-        telemetry_context: Optional[TelemetryContext],
         telemetry_parent: Optional[TelemetryParent],
     ) -> None:
         super().__init__(
             name=name,
             attributes=attributes,
-            telemetry_context=telemetry_context,
             telemetry_parent=telemetry_parent,
         )
 

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
@@ -353,7 +353,7 @@ class OpenTelemetry(Telemetry):
             instrumenting_module_name=self._telemetry_context.service_name,
             tracer_provider=OpenTelemetry._trace_provider,
         )
-        span = _tracer.start_span(
+        span: Span = _tracer.start_span(
             name=name,
             attributes=combined_attributes,
             context=ctx,
@@ -434,7 +434,7 @@ class OpenTelemetry(Telemetry):
             tracer_provider=OpenTelemetry._trace_provider,
         )
 
-        span = _tracer.start_span(
+        span: Span = _tracer.start_span(
             name=name,
             attributes=combined_attributes,
             context=ctx,

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
@@ -14,6 +14,7 @@ from typing import (
     Union,
     ClassVar,
     List,
+    Mapping,
 )
 
 from opentelemetry import trace, metrics
@@ -48,6 +49,10 @@ from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_co
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
     TelemetryUpDownCounter,
 )
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+    TelemetryAttributeValueWithoutNone,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
@@ -66,6 +71,10 @@ from spark_pipeline_framework.utilities.telemetry.telemetry_span_wrapper import 
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_tracers import (
     TelemetryTracer,
+)
+from spark_pipeline_framework.utilities.telemetry.utilities.mapping_appender import (
+    append_mappings,
+    remove_null_values,
 )
 
 
@@ -111,7 +120,7 @@ class OpenTelemetry(Telemetry):
 
         hostname: str = socket.gethostname()
 
-        self._metadata = {
+        self._metadata: Dict[str, TelemetryAttributeValue] = {
             "service.name": telemetry_context.service_name,
             "deployment.environment": telemetry_context.environment,
             "host.name": hostname,
@@ -120,7 +129,7 @@ class OpenTelemetry(Telemetry):
         }
 
         if telemetry_context.attributes:
-            self._metadata.update(telemetry_context.attributes)
+            self._metadata.update(remove_null_values(telemetry_context.attributes))
 
         # Create a resource with service details
         # from https://opentelemetry.io/docs/specs/semconv/resource/
@@ -290,17 +299,21 @@ class OpenTelemetry(Telemetry):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> Iterator[TelemetrySpanWrapper]:
         """
         Create a traced context with optional parent trace linking
         """
-        final_attributes = self._metadata
-        if telemetry_parent and telemetry_parent.attributes:
-            final_attributes.update(telemetry_parent.attributes)
-        if attributes:
-            final_attributes.update(attributes)
+        combined_attributes: Mapping[str, TelemetryAttributeValueWithoutNone] = (
+            append_mappings(
+                [
+                    self._metadata,
+                    telemetry_parent.attributes if telemetry_parent else {},
+                    attributes,
+                ]
+            )
+        )
 
         ctx: Optional[Context] = None
 
@@ -335,25 +348,18 @@ class OpenTelemetry(Telemetry):
                 f"OpenTelemetry {self._instance_id} trace_async created span wrapper for {name} without parent trace"
             )
 
-        # tracer cannot handle None attributes so ignore attributes that are None
-        final_attributes = {
-            k: v
-            for k, v in (final_attributes or {}).items()
-            if v is not None and type(v) in [bool, str, bytes, int, float]
-        }
-
         _tracer = trace.get_tracer(
             instrumenting_module_name=self._telemetry_context.service_name,
             tracer_provider=OpenTelemetry._trace_provider,
         )
         with _tracer.start_as_current_span(
             name=name,
-            attributes=final_attributes,
+            attributes=combined_attributes,
             context=ctx,
         ) as span:
             yield OpenTelemetrySpanWrapper(
                 name=name,
-                attributes=final_attributes,
+                attributes=combined_attributes,
                 span=span,
                 telemetry_context=self._telemetry_context,
                 telemetry_parent=telemetry_parent,
@@ -365,17 +371,21 @@ class OpenTelemetry(Telemetry):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> AsyncIterator[TelemetrySpanWrapper]:
         """
         Async version of trace with parent trace support
         """
-        final_attributes = self._metadata
-        if telemetry_parent and telemetry_parent.attributes:
-            final_attributes.update(telemetry_parent.attributes)
-        if attributes:
-            final_attributes.update(attributes)
+        combined_attributes: Mapping[str, TelemetryAttributeValueWithoutNone] = (
+            append_mappings(
+                [
+                    self._metadata,
+                    telemetry_parent.attributes if telemetry_parent else {},
+                    attributes,
+                ]
+            )
+        )
 
         ctx: Optional[Context] = None
 
@@ -410,25 +420,18 @@ class OpenTelemetry(Telemetry):
                 f"OpenTelemetry {self._instance_id} trace_async created span wrapper for {name} without parent trace"
             )
 
-        # tracer cannot handle None attributes so ignore attributes that are None
-        final_attributes = {
-            k: v
-            for k, v in (final_attributes or {}).items()
-            if v is not None and type(v) in [bool, str, bytes, int, float]
-        }
-
         _tracer = trace.get_tracer(
             instrumenting_module_name=self._telemetry_context.service_name,
             tracer_provider=OpenTelemetry._trace_provider,
         )
         with _tracer.start_as_current_span(
             name=name,
-            attributes=final_attributes,
+            attributes=combined_attributes,
             context=ctx,
         ) as span:
             yield OpenTelemetrySpanWrapper(
                 name=name,
-                attributes=final_attributes,
+                attributes=combined_attributes,
                 span=span,
                 telemetry_context=self._telemetry_context,
                 telemetry_parent=telemetry_parent,
@@ -465,7 +468,9 @@ class OpenTelemetry(Telemetry):
             current_span.record_exception(exception, attributes=additional_info or {})
 
     def add_event(
-        self, event_name: str, attributes: Optional[Dict[str, Any]] = None
+        self,
+        event_name: str,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> None:
         """
         Add a custom event to the current span
@@ -476,7 +481,10 @@ class OpenTelemetry(Telemetry):
         """
         current_span = trace.get_current_span()
         if current_span:
-            current_span.add_event(event_name, attributes=attributes or {})
+            current_span.add_event(
+                event_name,
+                attributes=remove_null_values(attributes) if attributes else {},
+            )
 
     async def shutdown_async(self) -> None:
         """
@@ -565,7 +573,7 @@ class OpenTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryCounter:
         """
         Get a counter metric
@@ -578,16 +586,20 @@ class OpenTelemetry(Telemetry):
         :return: The Counter metric
         """
 
-        final_attributes = self._metadata
-        if telemetry_parent and telemetry_parent.attributes:
-            final_attributes.update(telemetry_parent.attributes)
-        if attributes:
-            final_attributes.update(attributes)
+        combined_attributes: Mapping[str, TelemetryAttributeValueWithoutNone] = (
+            append_mappings(
+                [
+                    self._metadata,
+                    telemetry_parent.attributes if telemetry_parent else {},
+                    attributes,
+                ]
+            )
+        )
 
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
-            attributes=final_attributes,
+            attributes=combined_attributes,
         )
 
         # check if we already have a counter for this name
@@ -602,7 +614,7 @@ class OpenTelemetry(Telemetry):
 
         counter_wrapper: TelemetryCounter = TelemetryCounter(
             counter=counter,
-            attributes=final_attributes,
+            attributes=combined_attributes,
             telemetry_parent=telemetry_parent,
         )
         # add to the dictionary of counters
@@ -618,7 +630,7 @@ class OpenTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryUpDownCounter:
         """
         Get an up_down_counter metric
@@ -630,16 +642,20 @@ class OpenTelemetry(Telemetry):
         :param telemetry_parent: Parent telemetry context
         :return: The Counter metric
         """
-        final_attributes = self._metadata
-        if telemetry_parent and telemetry_parent.attributes:
-            final_attributes.update(telemetry_parent.attributes)
-        if attributes:
-            final_attributes.update(attributes)
+        combined_attributes: Mapping[str, TelemetryAttributeValueWithoutNone] = (
+            append_mappings(
+                [
+                    self._metadata,
+                    telemetry_parent.attributes if telemetry_parent else {},
+                    attributes,
+                ]
+            )
+        )
 
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
-            attributes=final_attributes,
+            attributes=combined_attributes,
         )
 
         # check if we already have an up_down_counter for this name
@@ -654,7 +670,7 @@ class OpenTelemetry(Telemetry):
 
         up_down_counter_wrapper: TelemetryUpDownCounter = TelemetryUpDownCounter(
             counter=up_down_counter,
-            attributes=final_attributes,
+            attributes=combined_attributes,
             telemetry_parent=telemetry_parent,
         )
         # add to the dictionary of counters
@@ -670,7 +686,7 @@ class OpenTelemetry(Telemetry):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryHistogram:
         """
         Get a histogram metric
@@ -682,16 +698,20 @@ class OpenTelemetry(Telemetry):
         :param telemetry_parent: Parent telemetry context
         :return: The Counter metric
         """
-        final_attributes = self._metadata
-        if telemetry_parent and telemetry_parent.attributes:
-            final_attributes.update(telemetry_parent.attributes)
-        if attributes:
-            final_attributes.update(attributes)
+        combined_attributes: Mapping[str, TelemetryAttributeValueWithoutNone] = (
+            append_mappings(
+                [
+                    self._metadata,
+                    telemetry_parent.attributes if telemetry_parent else {},
+                    attributes,
+                ]
+            )
+        )
 
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
-            attributes=final_attributes,
+            attributes=combined_attributes,
         )
 
         # check if we already have a histogram for this name
@@ -706,7 +726,7 @@ class OpenTelemetry(Telemetry):
 
         histogram_wrapper: TelemetryHistogram = TelemetryHistogram(
             histogram=histogram,
-            attributes=final_attributes,
+            attributes=combined_attributes,
             telemetry_parent=telemetry_parent,
         )
         # add to the dictionary of counters

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
@@ -364,7 +364,6 @@ class OpenTelemetry(Telemetry):
                 name=name,
                 attributes=combined_attributes,
                 span=span,
-                telemetry_context=self._telemetry_context,
                 telemetry_parent=telemetry_parent,
             )
 
@@ -446,7 +445,6 @@ class OpenTelemetry(Telemetry):
                 name=name,
                 attributes=combined_attributes,
                 span=span,
-                telemetry_context=self._telemetry_context,
                 telemetry_parent=telemetry_parent,
             )
 

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry.py
@@ -296,9 +296,11 @@ class OpenTelemetry(Telemetry):
         """
         Create a traced context with optional parent trace linking
         """
-        # Similar implementation to trace method
-        attributes = attributes or {}
-        attributes.update(self._metadata)
+        final_attributes = self._metadata
+        if telemetry_parent and telemetry_parent.attributes:
+            final_attributes.update(telemetry_parent.attributes)
+        if attributes:
+            final_attributes.update(attributes)
 
         ctx: Optional[Context] = None
 
@@ -334,9 +336,9 @@ class OpenTelemetry(Telemetry):
             )
 
         # tracer cannot handle None attributes so ignore attributes that are None
-        attributes = {
+        final_attributes = {
             k: v
-            for k, v in (attributes or {}).items()
+            for k, v in (final_attributes or {}).items()
             if v is not None and type(v) in [bool, str, bytes, int, float]
         }
 
@@ -346,12 +348,12 @@ class OpenTelemetry(Telemetry):
         )
         with _tracer.start_as_current_span(
             name=name,
-            attributes=attributes,
+            attributes=final_attributes,
             context=ctx,
         ) as span:
             yield OpenTelemetrySpanWrapper(
                 name=name,
-                attributes=attributes,
+                attributes=final_attributes,
                 span=span,
                 telemetry_context=self._telemetry_context,
                 telemetry_parent=telemetry_parent,
@@ -369,9 +371,11 @@ class OpenTelemetry(Telemetry):
         """
         Async version of trace with parent trace support
         """
-        # Similar implementation to trace method
-        attributes = attributes or {}
-        attributes.update(self._metadata)
+        final_attributes = self._metadata
+        if telemetry_parent and telemetry_parent.attributes:
+            final_attributes.update(telemetry_parent.attributes)
+        if attributes:
+            final_attributes.update(attributes)
 
         ctx: Optional[Context] = None
 
@@ -407,9 +411,9 @@ class OpenTelemetry(Telemetry):
             )
 
         # tracer cannot handle None attributes so ignore attributes that are None
-        attributes = {
+        final_attributes = {
             k: v
-            for k, v in (attributes or {}).items()
+            for k, v in (final_attributes or {}).items()
             if v is not None and type(v) in [bool, str, bytes, int, float]
         }
 
@@ -419,12 +423,12 @@ class OpenTelemetry(Telemetry):
         )
         with _tracer.start_as_current_span(
             name=name,
-            attributes=attributes,
+            attributes=final_attributes,
             context=ctx,
         ) as span:
             yield OpenTelemetrySpanWrapper(
                 name=name,
-                attributes=attributes,
+                attributes=final_attributes,
                 span=span,
                 telemetry_context=self._telemetry_context,
                 telemetry_parent=telemetry_parent,
@@ -560,6 +564,7 @@ class OpenTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryCounter:
         """
@@ -569,16 +574,20 @@ class OpenTelemetry(Telemetry):
         :param unit: Unit of the counter
         :param description: Description
         :param attributes: Additional attributes
+        :param telemetry_parent: Parent telemetry context
         :return: The Counter metric
         """
 
-        attributes = attributes or {}
-        attributes.update(self._metadata)
+        final_attributes = self._metadata
+        if telemetry_parent and telemetry_parent.attributes:
+            final_attributes.update(telemetry_parent.attributes)
+        if attributes:
+            final_attributes.update(attributes)
 
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
-            attributes=attributes,
+            attributes=final_attributes,
         )
 
         # check if we already have a counter for this name
@@ -593,7 +602,8 @@ class OpenTelemetry(Telemetry):
 
         counter_wrapper: TelemetryCounter = TelemetryCounter(
             counter=counter,
-            attributes=attributes,
+            attributes=final_attributes,
+            telemetry_parent=telemetry_parent,
         )
         # add to the dictionary of counters
         OpenTelemetry._counters[name] = counter_wrapper
@@ -607,6 +617,7 @@ class OpenTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryUpDownCounter:
         """
@@ -616,15 +627,19 @@ class OpenTelemetry(Telemetry):
         :param unit: Unit of the up_down_counter
         :param description: Description
         :param attributes: Additional attributes
+        :param telemetry_parent: Parent telemetry context
         :return: The Counter metric
         """
-        attributes = attributes or {}
-        attributes.update(self._metadata)
+        final_attributes = self._metadata
+        if telemetry_parent and telemetry_parent.attributes:
+            final_attributes.update(telemetry_parent.attributes)
+        if attributes:
+            final_attributes.update(attributes)
 
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
-            attributes=attributes,
+            attributes=final_attributes,
         )
 
         # check if we already have an up_down_counter for this name
@@ -639,7 +654,8 @@ class OpenTelemetry(Telemetry):
 
         up_down_counter_wrapper: TelemetryUpDownCounter = TelemetryUpDownCounter(
             counter=up_down_counter,
-            attributes=attributes,
+            attributes=final_attributes,
+            telemetry_parent=telemetry_parent,
         )
         # add to the dictionary of counters
         OpenTelemetry._up_down_counters[name] = up_down_counter_wrapper
@@ -653,6 +669,7 @@ class OpenTelemetry(Telemetry):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryHistogram:
         """
@@ -662,15 +679,19 @@ class OpenTelemetry(Telemetry):
         :param unit: Unit of the histogram
         :param description: Description
         :param attributes: Additional attributes
+        :param telemetry_parent: Parent telemetry context
         :return: The Counter metric
         """
-        attributes = attributes or {}
-        attributes.update(self._metadata)
+        final_attributes = self._metadata
+        if telemetry_parent and telemetry_parent.attributes:
+            final_attributes.update(telemetry_parent.attributes)
+        if attributes:
+            final_attributes.update(attributes)
 
         meter: Meter = metrics.get_meter(
             name=self._telemetry_context.service_name,
             meter_provider=OpenTelemetry._meter_provider,
-            attributes=attributes,
+            attributes=final_attributes,
         )
 
         # check if we already have a histogram for this name
@@ -684,7 +705,9 @@ class OpenTelemetry(Telemetry):
         )
 
         histogram_wrapper: TelemetryHistogram = TelemetryHistogram(
-            histogram=histogram, attributes=attributes
+            histogram=histogram,
+            attributes=final_attributes,
+            telemetry_parent=telemetry_parent,
         )
         # add to the dictionary of counters
         OpenTelemetry._histograms[name] = histogram_wrapper

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
@@ -1,6 +1,10 @@
-from typing import Optional, override, Any, Dict
+from typing import Optional, override, Any, Dict, Mapping
 
 from opentelemetry.trace import Span
+
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
@@ -18,7 +22,7 @@ class OpenTelemetrySpanWrapper(TelemetrySpanWrapper):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         span: Span,
         telemetry_context: Optional[TelemetryContext],
         telemetry_parent: Optional[TelemetryParent],

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
@@ -5,9 +5,6 @@ from opentelemetry.trace import Span
 from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
     TelemetryAttributeValue,
 )
-from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
-    TelemetryContext,
-)
 
 from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
     TelemetryParent,
@@ -24,7 +21,6 @@ class OpenTelemetrySpanWrapper(TelemetrySpanWrapper):
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         span: Span,
-        telemetry_context: Optional[TelemetryContext],
         telemetry_parent: Optional[TelemetryParent],
     ) -> None:
         super().__init__(
@@ -55,3 +51,7 @@ class OpenTelemetrySpanWrapper(TelemetrySpanWrapper):
     @override
     def set_attributes(self, attributes: Dict[str, Any]) -> None:
         self._span.set_attributes(attributes=attributes)
+
+    @override
+    def end(self, *, end_time: int) -> None:
+        self._span.end(end_time=end_time)

--- a/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
+++ b/spark_pipeline_framework/utilities/telemetry/open_telemetry_span.py
@@ -30,7 +30,6 @@ class OpenTelemetrySpanWrapper(TelemetrySpanWrapper):
         super().__init__(
             name=name,
             attributes=attributes,
-            telemetry_context=telemetry_context,
             telemetry_parent=telemetry_parent,
         )
         self._span: Span = span

--- a/spark_pipeline_framework/utilities/telemetry/telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABC
 from contextlib import asynccontextmanager, contextmanager
 
-from typing import Optional, Dict, Any, AsyncIterator, Iterator
+from typing import Optional, Dict, Any, AsyncIterator, Iterator, Mapping
 
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
     TelemetryCounter,
@@ -11,6 +11,9 @@ from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_co
 )
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
     TelemetryUpDownCounter,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
     TelemetryParent,
@@ -36,7 +39,7 @@ class Telemetry(ABC):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> Iterator[TelemetrySpanWrapper]:
         """
@@ -62,7 +65,7 @@ class Telemetry(ABC):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
     ) -> AsyncIterator[TelemetrySpanWrapper]:
         """
@@ -122,7 +125,7 @@ class Telemetry(ABC):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryCounter:
         """
         Get a counter metric
@@ -144,7 +147,7 @@ class Telemetry(ABC):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryUpDownCounter:
         """
         Get an up_down_counter metric
@@ -166,7 +169,7 @@ class Telemetry(ABC):
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryHistogram:
         """
         Get a histograms metric

--- a/spark_pipeline_framework/utilities/telemetry/telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry.py
@@ -41,6 +41,7 @@ class Telemetry(ABC):
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> Iterator[TelemetrySpanWrapper]:
         """
         Start a new span
@@ -48,6 +49,7 @@ class Telemetry(ABC):
         :param name:  name of the span
         :param attributes: optional attributes to add to the span
         :param telemetry_parent: parent span
+        :param start_time: start time
         :return: A context manager to use in a `with` statement
         """
         # This is never called but is here for mypy to understand this is a generator
@@ -67,6 +69,7 @@ class Telemetry(ABC):
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> AsyncIterator[TelemetrySpanWrapper]:
         """
         Start a new span
@@ -74,6 +77,7 @@ class Telemetry(ABC):
         :param name:  name of the span
         :param attributes: optional attributes to add to the span
         :param telemetry_parent: telemetry parent
+        :param start_time: start time
         :return: A context manager to use in a `with` statement
         """
         # This is never called but is here for mypy to understand this is a generator

--- a/spark_pipeline_framework/utilities/telemetry/telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry.py
@@ -121,6 +121,7 @@ class Telemetry(ABC):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryCounter:
         """
@@ -130,6 +131,7 @@ class Telemetry(ABC):
         :param unit: Unit of the counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         ...
@@ -141,6 +143,7 @@ class Telemetry(ABC):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryUpDownCounter:
         """
@@ -150,6 +153,7 @@ class Telemetry(ABC):
         :param unit: Unit of the up_down_counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         ...
@@ -161,6 +165,7 @@ class Telemetry(ABC):
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryHistogram:
         """
@@ -170,6 +175,7 @@ class Telemetry(ABC):
         :param unit: Unit of the histograms
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         ...

--- a/spark_pipeline_framework/utilities/telemetry/telemetry.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry.py
@@ -53,7 +53,6 @@ class Telemetry(ABC):
         :return: A context manager to use in a `with` statement
         """
         # This is never called but is here for mypy to understand this is a generator
-        # noinspection PyTypeChecker
         yield ConsoleTelemetrySpanWrapper(
             name=name,
             attributes=attributes,
@@ -81,7 +80,6 @@ class Telemetry(ABC):
         :return: A context manager to use in a `with` statement
         """
         # This is never called but is here for mypy to understand this is a generator
-        # noinspection PyTypeChecker
         yield ConsoleTelemetrySpanWrapper(
             name=name,
             attributes=attributes,

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_attribute_value.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_attribute_value.py
@@ -1,0 +1,4 @@
+from typing import TypeAlias
+
+TelemetryAttributeValueWithoutNone: TypeAlias = bool | str | bytes | int | float
+TelemetryAttributeValue: TypeAlias = TelemetryAttributeValueWithoutNone | None

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
@@ -1,8 +1,11 @@
 import dataclasses
-from typing import Optional, List, Any, Dict, Union
+from typing import Optional, List, Union, Mapping
 
 from dataclasses_json import DataClassJsonMixin
 
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_provider import (
     TelemetryProvider,
 )
@@ -28,7 +31,7 @@ class TelemetryContext(DataClassJsonMixin):
     environment: str
     """ Environment for the telemetry context """
 
-    attributes: Optional[Dict[str, Any]]
+    attributes: Optional[Mapping[str, TelemetryAttributeValue]]
     """ Additional attributes to include in telemetry """
 
     log_level: Optional[Union[int, str]]

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_context.py
@@ -37,12 +37,6 @@ class TelemetryContext(DataClassJsonMixin):
     log_level: Optional[Union[int, str]]
     """ Log level for the telemetry context """
 
-    trace_id: Optional[str] = None
-    """ Trace ID for the telemetry context """
-
-    span_id: Optional[str] = None
-    """ Span ID for the telemetry context """
-
     trace_all_calls: Optional[List[TelemetryTracer]] = None
     """ Whether to Trace certain calls like aiohttp, pymysql, etc """
 
@@ -61,8 +55,6 @@ class TelemetryContext(DataClassJsonMixin):
         """
         return TelemetryContext(
             provider=TelemetryProvider.NULL,
-            trace_id=None,
-            span_id=None,
             service_name="",
             environment="",
             attributes=None,
@@ -79,8 +71,6 @@ class TelemetryContext(DataClassJsonMixin):
         """
         return TelemetryContext(
             provider=self.provider,
-            trace_id=self.trace_id,
-            span_id=self.span_id,
             service_name=self.service_name,
             environment=self.environment,
             trace_all_calls=self.trace_all_calls,
@@ -90,17 +80,11 @@ class TelemetryContext(DataClassJsonMixin):
             service_namespace=self.service_namespace,
         )
 
-    def create_child_context(
-        self, *, trace_id: Optional[str], span_id: Optional[str]
-    ) -> "TelemetryContext":
+    def create_child_context(self) -> "TelemetryContext":
         """
         Create a child telemetry context
 
-        :param trace_id: trace ID for the child context
-        :param span_id: span ID for the child context
         :return: a child telemetry context
         """
         telemetry_context = self.copy()
-        telemetry_context.trace_id = trace_id
-        telemetry_context.span_id = span_id
         return telemetry_context

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_factory.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_factory.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 
-from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
-    TelemetryContext,
+from spark_pipeline_framework.utilities.telemetry.telemetry_parent import (
+    TelemetryParent,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_provider import (
     TelemetryProvider,
@@ -24,14 +24,14 @@ from spark_pipeline_framework.utilities.telemetry.telemetry_span_creator import 
 
 
 class TelemetryFactory:
-    def __init__(self, *, telemetry_context: TelemetryContext) -> None:
+    def __init__(self, *, telemetry_parent: TelemetryParent) -> None:
         """
         Telemetry factory used to create telemetry instances based on the telemetry context
 
 
-        :param telemetry_context: telemetry context
+        :param telemetry_parent: telemetry parent
         """
-        self.telemetry_context = telemetry_context
+        self.telemetry_parent = telemetry_parent
 
     def create(self, *, log_level: Optional[str | int]) -> Telemetry:
         """
@@ -39,20 +39,26 @@ class TelemetryFactory:
 
         :return: telemetry instance
         """
-        if not self.telemetry_context:
-            return NullTelemetry(telemetry_context=self.telemetry_context)
+        if not self.telemetry_parent.telemetry_context:
+            return NullTelemetry(
+                telemetry_context=self.telemetry_parent.telemetry_context
+            )
 
-        match self.telemetry_context.provider:
+        match self.telemetry_parent.telemetry_context.provider:
             case TelemetryProvider.CONSOLE:
                 return ConsoleTelemetry(
-                    telemetry_context=self.telemetry_context, log_level=log_level
+                    telemetry_context=self.telemetry_parent.telemetry_context,
+                    log_level=log_level,
                 )
             case TelemetryProvider.OPEN_TELEMETRY:
                 return OpenTelemetry(
-                    telemetry_context=self.telemetry_context, log_level=log_level
+                    telemetry_context=self.telemetry_parent.telemetry_context,
+                    log_level=log_level,
                 )
             case TelemetryProvider.NULL:
-                return NullTelemetry(telemetry_context=self.telemetry_context)
+                return NullTelemetry(
+                    telemetry_context=self.telemetry_parent.telemetry_context
+                )
             case _:
                 raise ValueError("Invalid telemetry provider")
 
@@ -66,13 +72,11 @@ class TelemetryFactory:
         """
         return TelemetrySpanCreator(
             telemetry=self.create(log_level=log_level),
-            telemetry_context=self.telemetry_context,
+            telemetry_context=self.telemetry_parent.telemetry_context,
         )
 
+    # noinspection PyTypeChecker
     def __getstate__(self) -> Dict[str, Any]:
-        # Exclude certain properties from being pickled otherwise they cause errors in pickling
-        return {
-            k: v
-            for k, v in self.__dict__.items()
-            if k not in ["_telemetry_factory", "_telemetry"]
-        }
+        raise NotImplementedError(
+            "Serialization of TelemetrySpanCreator is not supported.  Did you accidentally try to send this object to a Spark worker?"
+        )

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_factory.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_factory.py
@@ -72,7 +72,6 @@ class TelemetryFactory:
         """
         return TelemetrySpanCreator(
             telemetry=self.create(log_level=log_level),
-            telemetry_context=self.telemetry_parent.telemetry_context,
         )
 
     # noinspection PyTypeChecker

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_parent.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_parent.py
@@ -1,3 +1,4 @@
+from __future__ import annotations  # For self-referencing type hints
 import dataclasses
 from typing import Optional, Mapping
 
@@ -6,6 +7,12 @@ from dataclasses_json import DataClassJsonMixin
 from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
     TelemetryAttributeValue,
 )
+from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
+    TelemetryContext,
+)
+from spark_pipeline_framework.utilities.telemetry.utilities.mapping_appender import (
+    append_mappings,
+)
 
 
 @dataclasses.dataclass
@@ -13,11 +20,57 @@ class TelemetryParent(DataClassJsonMixin):
     name: str
     """ Name of the telemetry parent """
 
-    trace_id: str
+    trace_id: Optional[str]
     """ Trace ID for the telemetry context """
 
-    span_id: str
+    span_id: Optional[str]
     """ Span ID for the telemetry context """
 
     attributes: Optional[Mapping[str, TelemetryAttributeValue]]
     """ Attributes for the telemetry parent to inherit by children """
+
+    telemetry_context: TelemetryContext
+    """ Telemetry context for the telemetry parent """
+
+    def create_child_telemetry_parent(
+        self,
+        *,
+        attributes: Mapping[str, TelemetryAttributeValue] | None = None,
+        include_parent_attributes: bool = True,
+    ) -> TelemetryParent:
+        """
+        Creates a copy of the telemetry parent with the new trace and span ids
+
+
+        :return:
+        """
+        child_telemetry_context = self.telemetry_context.create_child_context()
+
+        child_telemetry_parent: TelemetryParent = TelemetryParent(
+            trace_id=self.trace_id,
+            span_id=self.span_id,
+            name=self.name,
+            attributes=(
+                append_mappings([self.attributes, attributes])
+                if include_parent_attributes
+                else attributes
+            ),
+            telemetry_context=child_telemetry_context,
+        )
+
+        return child_telemetry_parent
+
+    @classmethod
+    def get_null_parent(cls) -> TelemetryParent:
+        """
+        Get a null telemetry context
+
+        :return: a null telemetry context
+        """
+        return TelemetryParent(
+            name="Null",
+            trace_id=None,
+            span_id=None,
+            attributes=None,
+            telemetry_context=TelemetryContext.get_null_context(),
+        )

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_parent.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_parent.py
@@ -1,7 +1,11 @@
 import dataclasses
-from typing import Any, Dict, Optional
+from typing import Optional, Mapping
 
 from dataclasses_json import DataClassJsonMixin
+
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+)
 
 
 @dataclasses.dataclass
@@ -15,5 +19,5 @@ class TelemetryParent(DataClassJsonMixin):
     span_id: str
     """ Span ID for the telemetry context """
 
-    attributes: Optional[Dict[str, Any]]
+    attributes: Optional[Mapping[str, TelemetryAttributeValue]]
     """ Attributes for the telemetry parent to inherit by children """

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_parent.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_parent.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Any, Dict, Optional
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -13,3 +14,6 @@ class TelemetryParent(DataClassJsonMixin):
 
     span_id: str
     """ Span ID for the telemetry context """
+
+    attributes: Optional[Dict[str, Any]]
+    """ Attributes for the telemetry parent to inherit by children """

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -3,7 +3,6 @@ from contextlib import asynccontextmanager, contextmanager
 from logging import Logger
 from typing import Optional, Dict, Any, AsyncGenerator, Generator
 
-
 from spark_pipeline_framework.logger.yarn_logger import get_logger
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
     TelemetryCounter,
@@ -139,12 +138,13 @@ class TelemetrySpanCreator:
         if self.telemetry:
             await self.telemetry.flush_async()
 
-    def get_counter(
+    def get_telemetry_counter(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryCounter:
         """
@@ -154,18 +154,24 @@ class TelemetrySpanCreator:
         :param unit: Unit of the counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return self.telemetry.get_counter(
-            name=name, unit=unit, description=description, attributes=attributes
+            name=name,
+            unit=unit,
+            description=description,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )
 
-    def get_up_down_counter(
+    def get_telemetry_up_down_counter(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryUpDownCounter:
         """
@@ -175,18 +181,24 @@ class TelemetrySpanCreator:
         :param unit: Unit of the up_down_counter
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return self.telemetry.get_up_down_counter(
-            name=name, unit=unit, description=description, attributes=attributes
+            name=name,
+            unit=unit,
+            description=description,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )
 
-    def get_histogram(
+    def get_telemetry_histogram(
         self,
         *,
         name: str,
         unit: str,
         description: str,
+        telemetry_parent: Optional[TelemetryParent],
         attributes: Optional[Dict[str, Any]] = None,
     ) -> TelemetryHistogram:
         """
@@ -196,8 +208,13 @@ class TelemetrySpanCreator:
         :param unit: Unit of the histograms
         :param description: Description
         :param attributes: Optional attributes
+        :param telemetry_parent: telemetry parent
         :return: The Counter metric
         """
         return self.telemetry.get_histogram(
-            name=name, unit=unit, description=description, attributes=attributes
+            name=name,
+            unit=unit,
+            description=description,
+            attributes=attributes,
+            telemetry_parent=telemetry_parent,
         )

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -66,7 +66,7 @@ class TelemetrySpanCreator:
         )
 
     @asynccontextmanager
-    async def create_telemetry_span(
+    async def create_telemetry_span_async(
         self,
         *,
         name: str,
@@ -102,7 +102,7 @@ class TelemetrySpanCreator:
             )
 
     @contextmanager
-    def create_telemetry_span_sync(
+    def create_telemetry_span(
         self,
         *,
         name: str,

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -81,7 +81,7 @@ class TelemetrySpanCreator:
         :param attributes:  optional attributes to add to the span
         :param telemetry_parent: telemetry parent
         :param start_time: start time
-        :return: AsyncContextManager[Any]
+        :return: AsyncGenerator[TelemetrySpanWrapper, None]
         """
 
         if self.telemetry is not None:
@@ -117,7 +117,7 @@ class TelemetrySpanCreator:
         :param attributes:  optional attributes to add to the span
         :param telemetry_parent: telemetry parent
         :param start_time: start time
-        :return: AsyncContextManager[Any]
+        :return: Generator[TelemetrySpanWrapper, None, None]
         """
         if self.telemetry is not None:
             span: TelemetrySpanWrapper

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -72,6 +72,7 @@ class TelemetrySpanCreator:
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> AsyncGenerator[TelemetrySpanWrapper, None]:
         """
         Create a telemetry span if telemetry is available else return a null context
@@ -79,6 +80,7 @@ class TelemetrySpanCreator:
         :param name: name of the span
         :param attributes:  optional attributes to add to the span
         :param telemetry_parent: telemetry parent
+        :param start_time: start time
         :return: AsyncContextManager[Any]
         """
 
@@ -88,6 +90,7 @@ class TelemetrySpanCreator:
                 name=name,
                 attributes=attributes,
                 telemetry_parent=telemetry_parent,
+                start_time=start_time,
             ) as span:
                 yield span
         else:
@@ -105,6 +108,7 @@ class TelemetrySpanCreator:
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_parent: Optional[TelemetryParent],
+        start_time: int | None = None,
     ) -> Generator[TelemetrySpanWrapper, None, None]:
         """
         Create a telemetry span if telemetry is available else return a null context
@@ -112,6 +116,7 @@ class TelemetrySpanCreator:
         :param name: name of the span
         :param attributes:  optional attributes to add to the span
         :param telemetry_parent: telemetry parent
+        :param start_time: start time
         :return: AsyncContextManager[Any]
         """
         if self.telemetry is not None:
@@ -120,6 +125,7 @@ class TelemetrySpanCreator:
                 name=name,
                 attributes=attributes,
                 telemetry_parent=telemetry_parent,
+                start_time=start_time,
             ) as span:
                 yield span
         else:

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -39,7 +39,6 @@ class TelemetrySpanCreator:
         self,
         *,
         telemetry: Optional[Telemetry],
-        telemetry_context: TelemetryContext,
         log_level: str = "DEBUG",
     ) -> None:
         """
@@ -52,9 +51,7 @@ class TelemetrySpanCreator:
         self._instance_id = str(uuid.uuid4())
 
         assert telemetry is not None
-        assert telemetry_context is not None
         self.telemetry = telemetry
-        self._current_telemetry_context = telemetry_context
 
         self._logger: Logger = get_logger(
             __name__,

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -64,8 +64,9 @@ class TelemetrySpanCreator:
         self._logger.setLevel(log_level)
 
     def __getstate__(self) -> Dict[str, Any]:
-        # Exclude certain properties from being pickled otherwise they cause errors in pickling
-        return {k: v for k, v in self.__dict__.items() if k not in ["telemetry"]}
+        raise NotImplementedError(
+            "Serialization of TelemetrySpanCreator is not supported.  Did you accidentally try to send this object to a Spark worker?"
+        )
 
     @asynccontextmanager
     async def create_telemetry_span(
@@ -73,7 +74,7 @@ class TelemetrySpanCreator:
         *,
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]],
-        telemetry_parent: Optional[TelemetryParent] = None,
+        telemetry_parent: Optional[TelemetryParent],
     ) -> AsyncGenerator[TelemetrySpanWrapper, None]:
         """
         Create a telemetry span if telemetry is available else return a null context
@@ -106,7 +107,7 @@ class TelemetrySpanCreator:
         *,
         name: str,
         attributes: Optional[Mapping[str, TelemetryAttributeValue]],
-        telemetry_parent: Optional[TelemetryParent] = None,
+        telemetry_parent: Optional[TelemetryParent],
     ) -> Generator[TelemetrySpanWrapper, None, None]:
         """
         Create a telemetry span if telemetry is available else return a null context

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_creator.py
@@ -1,7 +1,7 @@
 import uuid
 from contextlib import asynccontextmanager, contextmanager
 from logging import Logger
-from typing import Optional, Dict, Any, AsyncGenerator, Generator
+from typing import Optional, Dict, Any, AsyncGenerator, Generator, Mapping
 
 from spark_pipeline_framework.logger.yarn_logger import get_logger
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_counter import (
@@ -12,6 +12,9 @@ from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_histogram_co
 )
 from spark_pipeline_framework.utilities.telemetry.metrics.telemetry_up_down_counter import (
     TelemetryUpDownCounter,
+)
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
 )
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
@@ -69,7 +72,7 @@ class TelemetrySpanCreator:
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_parent: Optional[TelemetryParent] = None,
     ) -> AsyncGenerator[TelemetrySpanWrapper, None]:
         """
@@ -102,7 +105,7 @@ class TelemetrySpanCreator:
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_parent: Optional[TelemetryParent] = None,
     ) -> Generator[TelemetrySpanWrapper, None, None]:
         """
@@ -145,7 +148,7 @@ class TelemetrySpanCreator:
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryCounter:
         """
         Get a counter metric
@@ -199,7 +202,7 @@ class TelemetrySpanCreator:
         unit: str,
         description: str,
         telemetry_parent: Optional[TelemetryParent],
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]] = None,
     ) -> TelemetryHistogram:
         """
         Get a histograms metric

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
@@ -3,8 +3,12 @@ from typing import (
     Optional,
     Dict,
     Any,
+    Mapping,
 )
 
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+)
 from spark_pipeline_framework.utilities.telemetry.telemetry_context import (
     TelemetryContext,
 )
@@ -19,7 +23,7 @@ class TelemetrySpanWrapper(ABC):
         self,
         *,
         name: str,
-        attributes: Optional[Dict[str, Any]],
+        attributes: Optional[Mapping[str, TelemetryAttributeValue]],
         telemetry_context: Optional[TelemetryContext],
         telemetry_parent: Optional[TelemetryParent],
     ) -> None:
@@ -31,7 +35,7 @@ class TelemetrySpanWrapper(ABC):
         :param telemetry_parent:
         """
         self.name: str = name
-        self.attributes: Optional[Dict[str, Any]] = attributes
+        self.attributes: Optional[Mapping[str, TelemetryAttributeValue]] = attributes
         self._telemetry_context: Optional[TelemetryContext] = telemetry_context
         self._telemetry_parent: Optional[TelemetryParent] = telemetry_parent
 

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
@@ -71,6 +71,7 @@ class TelemetrySpanWrapper(ABC):
                 trace_id=child_telemetry_context.trace_id,
                 span_id=child_telemetry_context.span_id,
                 name=self.name,
+                attributes=self.attributes,
             )
             if child_telemetry_context
             and child_telemetry_context.trace_id

--- a/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
+++ b/spark_pipeline_framework/utilities/telemetry/telemetry_span_wrapper.py
@@ -75,3 +75,12 @@ class TelemetrySpanWrapper(ABC):
     
     :param attributes: new attributes to add to the span
     """
+
+    @abstractmethod
+    def end(self, *, end_time: int) -> None: ...
+
+    """
+    This can be used to manually end a span with a specific end time
+    
+    :param end_time: end time of the span
+    """

--- a/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
+++ b/spark_pipeline_framework/utilities/telemetry/test/test_open_telemetry_multi_thread.py
@@ -83,8 +83,6 @@ async def run_sub_operation(
     print(f"Running sub-operation: {trace_id}, {span_id}, {carrier}")
 
     telemetry_context = TelemetryContext(
-        trace_id=trace_id,
-        span_id=span_id,
         service_name=service_name,
         environment=environment,
         provider=TelemetryProvider.OPEN_TELEMETRY,

--- a/spark_pipeline_framework/utilities/telemetry/utilities/mapping_appender.py
+++ b/spark_pipeline_framework/utilities/telemetry/utilities/mapping_appender.py
@@ -1,0 +1,38 @@
+from typing import Mapping, List, Dict
+
+from spark_pipeline_framework.utilities.telemetry.telemetry_attribute_value import (
+    TelemetryAttributeValue,
+    TelemetryAttributeValueWithoutNone,
+)
+
+
+def append_mappings(
+    mappings: List[Mapping[str, TelemetryAttributeValue] | None],
+) -> Mapping[str, TelemetryAttributeValueWithoutNone]:
+    """
+    Append mappings
+
+    :param mappings: List of mappings
+    :return: Aggregated mappings
+    """
+
+    final_attributes: Dict[str, TelemetryAttributeValue] = {}
+    for mapping in mappings:
+        if mapping:
+            final_attributes.update(mapping)
+
+    final_attributes_without_none = remove_null_values(final_attributes)
+
+    return final_attributes_without_none
+
+
+def remove_null_values(
+    final_attributes: Mapping[str, TelemetryAttributeValue],
+) -> Mapping[str, TelemetryAttributeValueWithoutNone]:
+    # tracer cannot handle None attributes so ignore attributes that are None
+    final_attributes_without_none: Mapping[str, TelemetryAttributeValueWithoutNone] = {
+        k: v
+        for k, v in (final_attributes or {}).items()
+        if v is not None and type(v) in [bool, str, bytes, int, float]
+    }
+    return final_attributes_without_none

--- a/spark_pipeline_framework/utilities/telemetry/utilities/mapping_appender.py
+++ b/spark_pipeline_framework/utilities/telemetry/utilities/mapping_appender.py
@@ -15,6 +15,7 @@ def append_mappings(
     :param mappings: List of mappings
     :return: Aggregated mappings
     """
+    assert mappings
 
     final_attributes: Dict[str, TelemetryAttributeValue] = {}
     for mapping in mappings:


### PR DESCRIPTION
1. New Mixins:
   - Added `LoopIdMixin` in `spark_pipeline_framework/mixins/loop_id_mixin.py`
   - Added `TelemetryParentMixin` in `spark_pipeline_framework/mixins/telemetry_parent_mixin.py`

2. Telemetry Architecture Refactoring:
   - Introduced `TelemetryParent` class to replace direct trace/span ID management
   - Created `TelemetryAttributeValue` type alias for better type safety
   - Added utility functions for mapping and attribute handling
   - Removed direct trace_id and span_id from TelemetryContext

3. Inheritance and Composition Changes:
   - Updated multiple classes to use `LoopIdMixin` and `TelemetryParentMixin`
   - Modified method signatures to support new telemetry parent concept
   - Replaced `set_telemetry_context` with `set_telemetry_parent`

4. Attribute Handling Improvements:
   - Added `append_mappings` and `remove_null_values` utility functions
   - Enhanced type safety for telemetry attributes
   - Prevented serialization of telemetry-related objects to avoid pickling issues

5. Specific File Changes:
   - Updated `framework_pipeline.py`
   - Updated `framework_transformer.py`
   - Updated various telemetry-related utility classes
   - Added new utility modules for mapping and attribute handling

6. Type Hinting and Safety:
   - Improved type hints across telemetry-related modules
   - Added more precise type annotations
   - Created type aliases for better type safety

7. Serialization Prevention:
   - Added `__getstate__` methods to prevent accidental serialization
   - Raised `NotImplementedError` for objects that shouldn't be pickled

8. Metrics and Tracing:
   - Updated metric creation methods to support new telemetry parent concept
   - Enhanced attribute handling in metrics
   - Improved span and context creation logic